### PR TITLE
Support composing directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ GraphQL stitching composes a single schema from multiple underlying GraphQL reso
 **Supports:**
 - Merged object and interface types.
 - Multiple keys per merged type.
-- Shared objects, enums, and inputs across locations.
+- Shared objects, fields, enums, and inputs across locations.
 - Combining local and remote schemas.
 
 **NOT Supported:**
-- Computed fields (ie: federation-style `@requires`)
-- Subscriptions
+- Computed fields (ie: federation-style `@requires`).
+- Subscriptions, defer/stream.
 
 This Ruby implementation is a sibling to [GraphQL Tools](https://the-guild.dev/graphql/stitching) (JS) and [Bramble](https://movio.github.io/bramble/) (Go), and its capabilities fall somewhere in between them. GraphQL stitching is similar in concept to [Apollo Federation](https://www.apollographql.com/docs/federation/), though more generic. While Ruby is not the fastest language for a high-throughput API gateway, the opportunity here is for a Ruby application to stitch its local schema onto a remote schema (making itself a superset of the remote) without requiring an additional gateway service.
 
@@ -70,7 +70,7 @@ result = gateway.execute(
 )
 ```
 
-Schemas provided to the `Gateway` constructor may be class-based schemas with local resolvers (locally-executable schemas), or schemas built from SDL strings (schema definition language parsed using `GraphQL::Schema.from_definition`) and mapped to remote locations.
+Schemas provided to the `Gateway` constructor may be class-based schemas with local resolvers (locally-executable schemas), or schemas built from SDL strings (schema definition language parsed using `GraphQL::Schema.from_definition`) and mapped to remote locations. See [composer docs](./docs/composer.md) for more information on how schemas get merged.
 
 While the [`Gateway`](./docs/gateway.md) constructor is an easy quick start, the library also has several discrete components that can be assembled into custom workflows:
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ shipping_schema = <<~GRAPHQL
   }
 GRAPHQL
 
-supergraph = GraphQL::Stitching::Composer.new({
+supergraph = GraphQL::Stitching::Composer.new(schemas: {
   "products" => GraphQL::Schema.from_definition(products_schema),
   "shipping" => GraphQL::Schema.from_definition(shipping_schema),
 })

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -1,6 +1,6 @@
 ## GraphQL::Stitching::Composer
 
-The `Composer` receives many individual `GraphQL:Schema` instances for various graph locations and _composes_ them into a combined [`Supergraph`](./supergraph.md) that is validated for integrity. The resulting context provides a combined GraphQL schema and delegation maps used to route incoming requests:
+The `Composer` receives many individual `GraphQL:Schema` instances for various graph locations and _composes_ them into a combined [`Supergraph`](./supergraph.md) that is validated for integrity. The resulting supergraph provides a combined GraphQL schema and delegation maps used to route incoming requests:
 
 ```ruby
 storefronts_sdl = <<~GRAPHQL
@@ -47,9 +47,9 @@ The individual schemas provided to the composer are assigned a location name bas
 
 The strategy used to merge source schemas into the combined schema is based on each element type:
 
-- `Object` and `Interface` types merge their fields together:
+- `Object` and `Interface` types merge their fields and directives together:
   - Common fields across locations must share a value type, and the weakest nullability is used.
-  - Field arguments merge using the same rules as `InputObject`.
+  - Field and directive arguments merge using the same rules as `InputObject`.
   - Objects with unique fields across locations must implement [`@stitch` accessors](../README.md#merged-types).
   - Shared object types without `@stitch` accessors must contain identical fields.
   - Merged interfaces must remain compatible with all underlying implementations.
@@ -65,5 +65,9 @@ The strategy used to merge source schemas into the combined schema is based on e
 - `Union` types merge all possible types from across all locations.
 
 - `Scalar` types are added for all scalar names across all locations.
+
+- `Directive` definitions are added for all distinct names across locations:
+  - Arguments merge using the same rules as `InputObject`.
+  - Stitching directives (both definitions and assignments) are omitted.
 
 Note that the structure of a composed schema may change based on new schema additions and/or element usage (ie: changing input object arguments in one service may cause the intersection of arguments to change). Therefore, it's highly recommended that you use a [schema comparator](https://github.com/xuorig/graphql-schema_comparator) to flag regressions across composed schema versions.

--- a/docs/supergraph.md
+++ b/docs/supergraph.md
@@ -6,7 +6,7 @@ A `Supergraph` is the singuar representation of a stitched graph. `Supergraph` i
 storefronts_sdl = "type Query { storefront(id: ID!): Storefront } ..."
 products_sdl = "type Query { product(id: ID!): Product } ..."
 
-supergraph = GraphQL::Stitching::Composer.new({
+supergraph = GraphQL::Stitching::Composer.new(schemas: {
   "storefronts" => GraphQL::Schema.from_definition(storefronts_sdl),
   "products" => GraphQL::Schema.from_definition(products_sdl),
 }).perform

--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -13,6 +13,10 @@ module GraphQL
       end
 
       attr_writer :stitch_directive
+
+      def stitching_directive_names
+        [stitch_directive]
+      end
     end
   end
 end

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/test/graphql/stitching/composer/merge_arguments_test.rb
+++ b/test/graphql/stitching/composer/merge_arguments_test.rb
@@ -8,18 +8,18 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "input Test { arg:Int! } type Query { test(arg:Test!):Int }"
     b = "input Test { arg:Int! } type Query { test(arg:Test!):Int }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "Int!", print_value_type(info.schema.types["Test"].arguments["arg"].type)
-    assert_equal "Test!", print_value_type(info.schema.types["Query"].fields["test"].arguments["arg"].type)
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal "Int!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
+    assert_equal "Test!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
   end
 
   def test_merged_arguments_use_strongest_nullability
     a = "input Test { arg:Int! } type Query { test(arg:Test):Int }"
     b = "input Test { arg:Int } type Query { test(arg:Test!):Int }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "Int!", print_value_type(info.schema.types["Test"].arguments["arg"].type)
-    assert_equal "Test!", print_value_type(info.schema.types["Query"].fields["test"].arguments["arg"].type)
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal "Int!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
+    assert_equal "Test!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
   end
 
   def test_merged_object_arguments_must_have_matching_named_types
@@ -44,27 +44,27 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "input Test { arg:[String!]! } type Query { test(arg:[Test!]!):String }"
     b = "input Test { arg:[String!]! } type Query { test(arg:[Test!]!):String }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[String!]!", print_value_type(info.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[Test!]!", print_value_type(info.schema.types["Query"].fields["test"].arguments["arg"].type)
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal "[String!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
+    assert_equal "[Test!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
   end
 
   def test_merged_arguments_use_strongest_list_structure
     a = "input Test { arg:[String!] } type Query { test(arg:[Test]!):String }"
     b = "input Test { arg:[String]! } type Query { test(arg:[Test!]):String }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[String!]!", print_value_type(info.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[Test!]!", print_value_type(info.schema.types["Query"].fields["test"].arguments["arg"].type)
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal "[String!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
+    assert_equal "[Test!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
   end
 
   def test_merged_arguments_allow_deep_list_structures
     a = "input Test { arg:[[String!]!]! } type Query { test(arg:[[Test!]!]!):String }"
     b = "input Test { arg:[[String]!] } type Query { test(arg:[[Test]!]):String }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[[String!]!]!", print_value_type(info.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[[Test!]!]!", print_value_type(info.schema.types["Query"].fields["test"].arguments["arg"].type)
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal "[[String!]!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
+    assert_equal "[[Test!]!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
   end
 
   def test_merged_object_arguments_must_have_matching_list_structures
@@ -89,33 +89,52 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = %{input Test { """a""" arg:String } type Query { test("""a""" arg:Test):String }}
     b = %{input Test { """b""" arg:String } type Query { test("""b""" arg:Test):String }}
 
-    info = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      description_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
     })
 
-    assert_equal "a/b", info.schema.types["Test"].arguments["arg"].description
-    assert_equal "a/b", info.schema.types["Query"].fields["test"].arguments["arg"].description
+    assert_equal "a/b", supergraph.schema.types["Test"].arguments["arg"].description
+    assert_equal "a/b", supergraph.schema.types["Query"].fields["test"].arguments["arg"].description
   end
 
-  def test_merges_field_deprecations
+  def test_merges_argument_deprecations
     a = %{input Test { arg:String @deprecated(reason:"a") } type Query { test(arg:Test @deprecated(reason:"a")):String }}
     b = %{input Test { arg:String @deprecated(reason:"b") } type Query { test(arg:Test @deprecated(reason:"b")):String }}
 
-    info = compose_definitions({ "a" => a, "b" => b }, {
-      deprecation_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      deprecation_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
     })
 
-    assert_equal "a/b", info.schema.types["Test"].arguments["arg"].deprecation_reason
-    assert_equal "a/b", info.schema.types["Query"].fields["test"].arguments["arg"].deprecation_reason
+    assert_equal "a/b", supergraph.schema.types["Test"].arguments["arg"].deprecation_reason
+    assert_equal "a/b", supergraph.schema.types["Query"].fields["test"].arguments["arg"].deprecation_reason
+  end
+
+  def test_merges_argument_directives
+    a = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on ARGUMENT_DEFINITION
+      type Query { test(arg:String @fizzbuzz(arg:"a")):String }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on ARGUMENT_DEFINITION
+      type Query { test(arg:String @fizzbuzz(arg:"b")):String }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    directive = supergraph.schema.types["Query"].fields["test"].arguments["arg"].directives.first
+    assert_equal "a/b", directive.arguments.keyword_arguments[:arg]
   end
 
   def test_intersects_optional_arguments
     a = "input Test { arg1:String arg2:String } type Query { test(arg1:Test, arg2:String):String }"
     b = "input Test { arg3:String arg2:String } type Query { test(arg3:Test, arg2:String):String }"
 
-    info = compose_definitions({ "a" => a, "b" => b })
-    assert_equal ["arg2"], info.schema.types["Test"].arguments.keys.sort
-    assert_equal ["arg2"], info.schema.types["Query"].fields["test"].arguments.keys.sort
+    supergraph = compose_definitions({ "a" => a, "b" => b })
+    assert_equal ["arg2"], supergraph.schema.types["Test"].arguments.keys.sort
+    assert_equal ["arg2"], supergraph.schema.types["Query"].fields["test"].arguments.keys.sort
   end
 
   def test_fails_to_merge_isolated_required_object_arguments

--- a/test/graphql/stitching/composer/merge_directive_test.rb
+++ b/test/graphql/stitching/composer/merge_directive_test.rb
@@ -4,20 +4,18 @@ require "test_helper"
 
 describe 'GraphQL::Stitching::Composer, merging directives' do
 
-  def test_merges_directives
+  def test_merges_directive_definitions
     a = <<~GRAPHQL
       """a"""
-      directive @fizz(a: String!) on OBJECT
-      directive @bang on OBJECT
-      type Test @fizz(a: "A") { field: String }
+      directive @fizzbuzz(a: String!) on OBJECT
+      type Test @fizzbuzz(a: "A") { field: String }
       type Query { test: Test }
     GRAPHQL
 
     b = <<~GRAPHQL
       """b"""
-      directive @fizz(a: String!, b: String) on OBJECT
-      directive @widget on OBJECT
-      type Test @fizz(a: "A", b: "B") { field: String }
+      directive @fizzbuzz(a: String!, b: String) on OBJECT
+      type Test @fizzbuzz(a: "A", b: "B") { field: String }
       type Query { test: Test }
     GRAPHQL
 
@@ -25,8 +23,56 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
       description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
     })
 
-    #puts supergraph.schema.to_definition
-    # assert_equal "a/b", info.schema.types["Test"].description
-    # @todo
+    directive_definition = supergraph.schema.directives["fizzbuzz"]
+    assert_equal "a/b", directive_definition.description
+    assert_equal ["a"], directive_definition.arguments.keys
+  end
+
+  def test_combines_distinct_directives_assigned_to_an_element
+    a = <<~GRAPHQL
+      directive @fizz(arg: String!) on OBJECT
+      directive @buzz on OBJECT
+      type Test @fizz(arg: "a") @buzz { field: String }
+      type Query { test:Test }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizz(arg: String!) on OBJECT
+      directive @widget on OBJECT
+      type Test @fizz(arg: "b") @widget { field: String }
+      type Query { test:Test }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    directives = supergraph.schema.types["Test"].directives
+
+    assert_equal 3, directives.length
+    assert_equal ["buzz", "fizz", "widget"], directives.map(&:graphql_name).sort
+    assert_equal "a/b", directives.find { _1.graphql_name == "fizz" }.arguments.keyword_arguments[:arg]
+  end
+
+  def test_omits_stitching_directives
+    a = <<~GRAPHQL
+      directive @stitch(key: String!) repeatable on FIELD_DEFINITION
+      type Test { id: ID! a: String }
+      type Query { testA(id: ID!): Test @stitch(key: "id") }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @stitch(key: String!) repeatable on FIELD_DEFINITION
+      type Test { id: ID! b: String }
+      type Query { testB(id: ID!): Test @stitch(key: "id") }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    assert_nil supergraph.schema.directives["stitch"]
+    assert_equal 0, supergraph.schema.types["Query"].fields["testA"].directives.length
+    assert_equal 0, supergraph.schema.types["Query"].fields["testB"].directives.length
   end
 end

--- a/test/graphql/stitching/composer/merge_directive_test.rb
+++ b/test/graphql/stitching/composer/merge_directive_test.rb
@@ -25,7 +25,8 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
       description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
     })
 
-    puts supergraph.schema.to_definition
+    #puts supergraph.schema.to_definition
     # assert_equal "a/b", info.schema.types["Test"].description
+    # @todo
   end
 end

--- a/test/graphql/stitching/composer/merge_directive_test.rb
+++ b/test/graphql/stitching/composer/merge_directive_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe 'GraphQL::Stitching::Composer, merging directives' do
+
+  def test_merges_directives
+    a = <<~GRAPHQL
+      """a"""
+      directive @fizz(a: String!) on OBJECT
+      directive @bang on OBJECT
+      type Test @fizz(a: "A") { field: String }
+      type Query { test: Test }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      """b"""
+      directive @fizz(a: String!, b: String) on OBJECT
+      directive @widget on OBJECT
+      type Test @fizz(a: "A", b: "B") { field: String }
+      type Query { test: Test }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+    })
+
+    puts supergraph.schema.to_definition
+    # assert_equal "a/b", info.schema.types["Test"].description
+  end
+end

--- a/test/graphql/stitching/composer/merge_enum_test.rb
+++ b/test/graphql/stitching/composer/merge_enum_test.rb
@@ -8,38 +8,59 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
     a = %{"""a""" enum Status { """a""" YES } type Query { status:Status }}
     b = %{"""b""" enum Status { """b""" YES } type Query { status:Status }}
 
-    info = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      description_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
     })
 
-    assert_equal "a/b", info.schema.types["Status"].description
-    assert_equal "a/b", info.schema.types["Status"].values["YES"].description
+    assert_equal "a/b", supergraph.schema.types["Status"].description
+    assert_equal "a/b", supergraph.schema.types["Status"].values["YES"].description
+  end
+
+  def test_merges_enum_and_value_directives
+    a = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on ENUM | ENUM_VALUE
+      enum Status @fizzbuzz(arg: "a") { YES @fizzbuzz(arg: "a") }
+      type Query { status:Status }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on ENUM | ENUM_VALUE
+      enum Status @fizzbuzz(arg: "b") { YES @fizzbuzz(arg: "b") }
+      type Query { status:Status }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    assert_equal "a/b", supergraph.schema.types["Status"].directives.first.arguments.keyword_arguments[:arg]
+    assert_equal "a/b", supergraph.schema.types["Status"].values["YES"].directives.first.arguments.keyword_arguments[:arg]
   end
 
   def test_merges_enum_values_using_union_when_readonly
     a = %{enum Status { YES NO } type Query { status:Status }}
     b = %{enum Status { YES NO MAYBE } type Query { status:Status }}
 
-    info = compose_definitions({ "a" => a, "b" => b })
+    supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    assert_equal ["MAYBE", "NO", "YES"], info.schema.types["Status"].values.keys.sort
+    assert_equal ["MAYBE", "NO", "YES"], supergraph.schema.types["Status"].values.keys.sort
   end
 
   def test_merges_enum_values_using_intersection_when_input_via_field_arg
     a = %{enum Status { YES NO } type Query { status1:Status }}
     b = %{enum Status { YES NO MAYBE } type Query { status2(s:Status):Status }}
 
-    info = compose_definitions({ "a" => a, "b" => b })
+    supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    assert_equal ["NO", "YES"], info.schema.types["Status"].values.keys.sort
+    assert_equal ["NO", "YES"], supergraph.schema.types["Status"].values.keys.sort
   end
 
   def test_merges_enum_values_using_intersection_when_input_via_object
     a = %{enum Status { YES NO } input MyStatus { status:Status } type Query { status1(s:MyStatus):Status }}
     b = %{enum Status { YES NO MAYBE } type Query { status:Status }}
 
-    info = compose_definitions({ "a" => a, "b" => b })
+    supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    assert_equal ["NO", "YES"], info.schema.types["Status"].values.keys.sort
+    assert_equal ["NO", "YES"], supergraph.schema.types["Status"].values.keys.sort
   end
 end

--- a/test/graphql/stitching/composer/merge_input_object_test.rb
+++ b/test/graphql/stitching/composer/merge_input_object_test.rb
@@ -14,4 +14,25 @@ describe 'GraphQL::Stitching::Composer, merging input objects' do
 
     assert_equal "a/b", info.schema.types["Test"].description
   end
+
+  def test_merges_input_object_and_field_directives
+    a = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on INPUT_OBJECT | INPUT_FIELD_DEFINITION
+      input Test @fizzbuzz(arg: "a") { field:String @fizzbuzz(arg: "a") }
+      type Query { get(test:Test):String }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on INPUT_OBJECT | INPUT_FIELD_DEFINITION
+      input Test @fizzbuzz(arg: "b") { field:String @fizzbuzz(arg: "b") }
+      type Query { get(test:Test):String }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    assert_equal "a/b", supergraph.schema.types["Test"].directives.first.arguments.keyword_arguments[:arg]
+    assert_equal "a/b", supergraph.schema.types["Test"].arguments["field"].directives.first.arguments.keyword_arguments[:arg]
+  end
 end

--- a/test/graphql/stitching/composer/merge_object_test.rb
+++ b/test/graphql/stitching/composer/merge_object_test.rb
@@ -15,6 +15,26 @@ describe 'GraphQL::Stitching::Composer, merging objects' do
     assert_equal "a/b", info.schema.types["Test"].description
   end
 
+  def test_merges_object_directives
+    a = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on OBJECT
+      type Test @fizzbuzz(arg: "a") { field: String }
+      type Query { test:Test }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on OBJECT
+      type Test @fizzbuzz(arg: "b") { field: String }
+      type Query { test:Test }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    assert_equal "a/b", supergraph.schema.types["Test"].directives.first.arguments.keyword_arguments[:arg]
+  end
+
   def test_merges_interface_memberships
     a = %{interface A { id:ID } type C implements A { id:ID } type Query { c:C }}
     b = %{interface B { id:ID } type C implements B { id:ID } type Query { c:C }}

--- a/test/graphql/stitching/composer/merge_scalar_test.rb
+++ b/test/graphql/stitching/composer/merge_scalar_test.rb
@@ -14,4 +14,24 @@ describe 'GraphQL::Stitching::Composer, merging scalars' do
 
     assert_equal "a/b", info.schema.types["URL"].description
   end
+
+  def test_merges_scalar_directives
+    a = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on SCALAR
+      scalar Thing @fizzbuzz(arg: "a")
+      type Query { thing:Thing }
+    GRAPHQL
+
+    b = <<~GRAPHQL
+      directive @fizzbuzz(arg: String!) on SCALAR
+      scalar Thing @fizzbuzz(arg: "b")
+      type Query { thing:Thing }
+    GRAPHQL
+
+    supergraph = compose_definitions({ "a" => a, "b" => b }, {
+      directive_kwarg_merger: ->(str_by_location, _supergraph) { str_by_location.values.join("/") }
+    })
+
+    assert_equal "a/b", supergraph.schema.types["Thing"].directives.first.arguments.keyword_arguments[:arg]
+  end
 end


### PR DESCRIPTION
The initial composer completely omitted directives. This adds support for composing aggregate directive definitions and merging the directives applied to elements.