### PR TITLE
Improve interface validations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ Gemfile.lock
 .dat*
 .repl_history
 build/
+node_modules/
+package-lock.json
 *.bridgesupport
 build-iPhoneOS/
 build-iPhoneSimulator/

--- a/lib/graphql/stitching/composer/validate_interfaces.rb
+++ b/lib/graphql/stitching/composer/validate_interfaces.rb
@@ -12,32 +12,34 @@ module GraphQL
           next unless interface_type.kind.interface?
 
           supergraph.schema.possible_types(interface_type).each do |possible_type|
-            type_candidates_by_location = composer.subschema_types_by_name_and_location[possible_type.graphql_name]
+            interface_type.fields.each do |field_name, interface_field|
+              # graphql-ruby will dynamically apply interface fields on a type implementation,
+              # so check the delegation map to assure that all materialized fields have resolver locations.
+              unless supergraph.locations_by_type_and_field[possible_type.graphql_name][field_name]&.any?
+                raise Composer::ValidationError, "Type #{possible_type.graphql_name} does not implement a `#{field_name}` field in any location, "\
+                  "which is required by interface #{interface_type.graphql_name}."
+              end
 
-            type_candidates_by_location.each do |location, candidate_type|
-              intersecting_field_names = candidate_type.fields.keys & interface_type.fields.keys
+              intersecting_field = possible_type.fields[field_name]
+              interface_type_structure = Util.flatten_type_structure(interface_field.type)
+              possible_type_structure = Util.flatten_type_structure(intersecting_field.type)
 
-              intersecting_field_names.each do |field_name|
-                candidate_type_structure = Util.flatten_type_structure(candidate_type.fields[field_name].type)
-                interface_type_structure = Util.flatten_type_structure(interface_type.fields[field_name].type)
+              if possible_type_structure.length != interface_type_structure.length
+                raise Composer::ValidationError, "Incompatible list structures between field #{possible_type.graphql_name}.#{field_name} of type "\
+                  "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
+              end
 
-                if candidate_type_structure.length != interface_type_structure.length
-                  raise Composer::ValidationError, "Field type of #{candidate_type.graphql_name}.#{field_name} must match "\
-                    "list structure of merged interface #{interface_type.graphql_name}.#{field_name}."
+              interface_type_structure.each_with_index do |interface_struct, index|
+                possible_struct = possible_type_structure[index]
+
+                if possible_struct[:name] != interface_struct[:name]
+                  raise Composer::ValidationError, "Incompatible named types between field #{possible_type.graphql_name}.#{field_name} of type "\
+                    "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end
 
-                interface_type_structure.each_with_index do |istruct, index|
-                  cstruct = candidate_type_structure[index]
-
-                  if cstruct[:name] != istruct[:name]
-                    raise Composer::ValidationError, "Field type of #{candidate_type.graphql_name}.#{field_name} must match "\
-                      "merged interface #{interface_type.graphql_name}.#{field_name}."
-                  end
-
-                  if cstruct[:null] && !istruct[:null]
-                    raise Composer::ValidationError, "Field type of #{candidate_type.graphql_name}.#{field_name} must match "\
-                      "non-null status of merged interface #{interface_type.graphql_name}.#{field_name}."
-                  end
+                if possible_struct[:null] && !interface_struct[:null]
+                  raise Composer::ValidationError, "Incompatible nullability between field #{possible_type.graphql_name}.#{field_name} of type "\
+                    "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end
               end
             end

--- a/lib/graphql/stitching/gateway.rb
+++ b/lib/graphql/stitching/gateway.rb
@@ -35,9 +35,9 @@ module GraphQL
           return error_result(validation_errors) if validation_errors.any?
         end
 
-        request.prepare!
-
         begin
+          request.prepare!
+
           plan = fetch_plan(request) do
             GraphQL::Stitching::Planner.new(
               supergraph: @supergraph,

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -14,6 +14,7 @@ module GraphQL
         type
       end
 
+      # builds a single-dimensional representation of a wrapped type structure
       def self.flatten_type_structure(type)
         structure = []
 

--- a/test/graphql/stitching/composer/merge_arguments_test.rb
+++ b/test/graphql/stitching/composer/merge_arguments_test.rb
@@ -9,8 +9,8 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = "input Test { arg:Int! } type Query { test(arg:Test!):Int }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "Int!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
-    assert_equal "Test!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
+    assert_equal "Int!", supergraph.schema.types["Test"].arguments["arg"].type.to_type_signature
+    assert_equal "Test!", supergraph.schema.types["Query"].fields["test"].arguments["arg"].type.to_type_signature
   end
 
   def test_merged_arguments_use_strongest_nullability
@@ -18,8 +18,8 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = "input Test { arg:Int } type Query { test(arg:Test!):Int }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "Int!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
-    assert_equal "Test!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
+    assert_equal "Int!", supergraph.schema.types["Test"].arguments["arg"].type.to_type_signature
+    assert_equal "Test!", supergraph.schema.types["Query"].fields["test"].arguments["arg"].type.to_type_signature
   end
 
   def test_merged_object_arguments_must_have_matching_named_types
@@ -45,8 +45,8 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = "input Test { arg:[String!]! } type Query { test(arg:[Test!]!):String }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[String!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[Test!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
+    assert_equal "[String!]!", supergraph.schema.types["Test"].arguments["arg"].type.to_type_signature
+    assert_equal "[Test!]!", supergraph.schema.types["Query"].fields["test"].arguments["arg"].type.to_type_signature
   end
 
   def test_merged_arguments_use_strongest_list_structure
@@ -54,8 +54,8 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = "input Test { arg:[String]! } type Query { test(arg:[Test!]):String }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[String!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[Test!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
+    assert_equal "[String!]!", supergraph.schema.types["Test"].arguments["arg"].type.to_type_signature
+    assert_equal "[Test!]!", supergraph.schema.types["Query"].fields["test"].arguments["arg"].type.to_type_signature
   end
 
   def test_merged_arguments_allow_deep_list_structures
@@ -63,8 +63,8 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = "input Test { arg:[[String]!] } type Query { test(arg:[[Test]!]):String }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[[String!]!]!", print_value_type(supergraph.schema.types["Test"].arguments["arg"].type)
-    assert_equal "[[Test!]!]!", print_value_type(supergraph.schema.types["Query"].fields["test"].arguments["arg"].type)
+    assert_equal "[[String!]!]!", supergraph.schema.types["Test"].arguments["arg"].type.to_type_signature
+    assert_equal "[[Test!]!]!", supergraph.schema.types["Query"].fields["test"].arguments["arg"].type.to_type_signature
   end
 
   def test_merged_object_arguments_must_have_matching_list_structures

--- a/test/graphql/stitching/composer/merge_fields_test.rb
+++ b/test/graphql/stitching/composer/merge_fields_test.rb
@@ -49,7 +49,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = "type Test { field: String! } type Query { test:Test }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "String!", print_value_type(supergraph.schema.types["Test"].fields["field"].type)
+    assert_equal "String!", supergraph.schema.types["Test"].fields["field"].type.to_type_signature
   end
 
   def test_merged_fields_use_weakest_nullability
@@ -57,7 +57,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = "type Test { field: String } type Query { test:Test }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "String", print_value_type(supergraph.schema.types["Test"].fields["field"].type)
+    assert_equal "String", supergraph.schema.types["Test"].fields["field"].type.to_type_signature
   end
 
   def test_merged_fields_must_have_matching_named_types
@@ -74,7 +74,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = "type Test { field: [String!]! } type Query { test:Test }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[String!]!", print_value_type(supergraph.schema.types["Test"].fields["field"].type)
+    assert_equal "[String!]!", supergraph.schema.types["Test"].fields["field"].type.to_type_signature
   end
 
   def test_merged_fields_use_weakest_list_structure
@@ -83,7 +83,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     c = "type Test { field: [String]! } type Query { test:Test }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c })
-    assert_equal "[String]", print_value_type(supergraph.schema.types["Test"].fields["field"].type)
+    assert_equal "[String]", supergraph.schema.types["Test"].fields["field"].type.to_type_signature
   end
 
   def test_merged_fields_allow_deep_list_structures
@@ -91,7 +91,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = "type Test { field: [[String]!] } type Query { test:Test }"
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
-    assert_equal "[[String]!]", print_value_type(supergraph.schema.types["Test"].fields["field"].type)
+    assert_equal "[[String]!]", supergraph.schema.types["Test"].fields["field"].type.to_type_signature
   end
 
   def test_merged_fields_must_have_matching_list_structures

--- a/test/graphql/stitching/composer/validate_interfaces_test.rb
+++ b/test/graphql/stitching/composer/validate_interfaces_test.rb
@@ -15,7 +15,7 @@ describe 'GraphQL::Stitching::Composer, validate interfaces' do
       type Query { b: Gadget }
     |
 
-    assert_error('Field type of Gadget.value must match merged interface Widget.value', ValidationError) do
+    assert_error('Incompatible named types between field Gadget.value of type Int! and interface Widget.value of type String!', ValidationError) do
        compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -32,7 +32,7 @@ describe 'GraphQL::Stitching::Composer, validate interfaces' do
       type Query { b: Gadget }
     |
 
-    assert_error('Field type of Gadget.value must match list structure of merged interface Widget.value', ValidationError) do
+    assert_error('Incompatible list structures between field Gadget.value of type String! and interface Widget.value of type [String]!', ValidationError) do
        compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -49,8 +49,25 @@ describe 'GraphQL::Stitching::Composer, validate interfaces' do
       type Query { b: Gadget }
     |
 
-    assert_error('Field type of Gadget.value must match non-null status of merged interface Widget.value', ValidationError) do
+    assert_error('Incompatible nullability between field Gadget.value of type String and interface Widget.value of type String!', ValidationError) do
        compose_definitions({ "a" => a, "b" => b })
+    end
+  end
+
+  def test_errors_for_missing_fields_in_inherited_interfaces
+    a = %|
+      interface Widget { id: ID! value: String! }
+      type Gizmo implements Widget { id: ID! value: String! }
+      type Query { a: Gizmo }
+    |
+    b = %|
+      interface Widget { id: ID! }
+      type Gadget implements Widget { id: ID! }
+      type Query { b: Gadget }
+    |
+
+    assert_error('Type Gadget does not implement a `value` field in any location, which is required by interface Widget', ValidationError) do
+      compose_definitions({ "a" => a, "b" => b })
     end
   end
 end

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -37,25 +37,25 @@ describe "GraphQL::Stitching::Request" do
     assert_equal "sprocket", request2.operation.selections.first.name
   end
 
-  def test_errors_for_multiple_operations_given_without_operation_name
+  def test_operation_errors_for_multiple_operations_given_without_operation_name
     query = "query First { widget { id } } query Second { sprocket { id } }"
 
     assert_error "An operation name is required", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new(query)
+      GraphQL::Stitching::Request.new(query).operation
     end
   end
 
-  def test_errors_for_invalid_operation_names
+  def test_operation_errors_for_invalid_operation_names
     query = "query First { widget { id } } query Second { sprocket { id } }"
 
     assert_error "Invalid root operation", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new(query, operation_name: "Invalid")
+      GraphQL::Stitching::Request.new(query, operation_name: "Invalid").operation
     end
   end
 
-  def test_errors_for_invalid_operation_types
+  def test_operation_errors_for_invalid_operation_types
     assert_error "Invalid root operation", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new("subscription { movie }")
+      GraphQL::Stitching::Request.new("subscription { movie }").operation
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,33 +68,10 @@ def extract_types_of_kind(schema, kind)
   schema.types.values.select { _1.kind.object? && !_1.graphql_name.start_with?("__") }
 end
 
-# prints a wrapped field/argument value type as GraphQL SDL
-def print_value_type(type)
-  base_name = type.unwrap.graphql_name
-  wrappers = []
-
-  while type.respond_to?(:of_type)
-    if type.is_a?(GraphQL::Schema::NonNull)
-      wrappers << :non_null
-    elsif type.is_a?(GraphQL::Schema::List)
-      wrappers << :list
-    end
-    type = type.of_type
-  end
-
-  wrappers.reverse!.reduce(base_name) do |memo, wrapper|
-    case wrapper
-    when :non_null
-      "#{memo}!"
-    when :list
-      "[#{memo}]"
-    end
-  end
-end
-
 def assert_error(pattern, klass=nil)
   begin
     yield
+    flunk "No error was raised."
   rescue StandardError => e
     if pattern.is_a?(String)
       assert e.message.include?(pattern), "Unexpected error message: #{e.message}"


### PR DESCRIPTION
Improves merged interface validations, which currently may overlook missing object field resolvers when a field is acquired through a merged interface.

Also fixes an oversight in error testing, and makes some adjustments to fix oversights in existing tests.