### PR TITLE
Allow selection of root field locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ GraphQL stitching composes a single schema from multiple underlying GraphQL reso
 ![Stitched graph](./docs/images/stitching.png)
 
 **Supports:**
-- Merged object and interface types.
+- Merged object and abstract types.
 - Multiple keys per merged type.
 - Shared objects, fields, enums, and inputs across locations.
 - Combining local and remote schemas.
@@ -70,9 +70,9 @@ result = gateway.execute(
 )
 ```
 
-Schemas provided to the `Gateway` constructor may be class-based schemas with local resolvers (locally-executable schemas), or schemas built from SDL strings (schema definition language parsed using `GraphQL::Schema.from_definition`) and mapped to remote locations. See [composer docs](./docs/composer.md#merge-patterns) for more information on how schemas get merged.
+Schemas provided as [location settings](./docs/composer.md#performing-composition) may be class-based schemas with local resolvers (locally-executable schemas), or schemas built from SDL strings (schema definition language parsed using `GraphQL::Schema.from_definition`) and mapped to remote locations. See [composer docs](./docs/composer.md#merge-patterns) for more information on how schemas get merged.
 
-While the [`Gateway`](./docs/gateway.md) constructor is an easy quick start, the library also has several discrete components that can be assembled into custom workflows:
+While the `Gateway` constructor is an easy quick start, the library also has several discrete components that can be assembled into custom workflows:
 
 - [Composer](./docs/composer.md) - merges and validates many schemas into one supergraph.
 - [Supergraph](./docs/supergraph.md) - manages the combined schema, location routing maps, and executable resources. Can be exported, cached, and rehydrated.
@@ -148,7 +148,7 @@ type Query {
 * The `@stitch` directive is applied to a root query where the merged type may be accessed. The merged type identity is inferred from the field return.
 * The `key: "id"` parameter indicates that an `{ id }` must be selected from prior locations so it may be submitted as an argument to this query. The query argument used to send the key is inferred when possible (more on arguments later).
 
-Each location that provides a unique variant of a type must provide _exactly one_ stitching query per possible key (more on multiple keys later). The exception to this requirement are types that contain only a single key field:
+Each location that provides a unique variant of a type must provide one stitching query per key. The exception to this requirement are types that contain only a single key field:
 
 ```graphql
 type Product {
@@ -166,6 +166,9 @@ It's okay ([even preferable](https://www.youtube.com/watch?v=VmK0KBHTcWs) in man
 type Query {
   products(ids: [ID!]!): [Product]! @stitch(key: "id")
 }
+
+# input:  ["1", "2", "3"]
+# result: [{ id: "1" }, null, { id: "3" }]
 ```
 
 #### Abstract queries

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -13,6 +13,7 @@ composer = GraphQL::Stitching::Composer.new(
   description_merger: ->(values_by_location, info) { values_by_location.values.join("\n") },
   deprecation_merger: ->(values_by_location, info) { values_by_location.values.first },
   directive_kwarg_merger: ->(values_by_location, info) { values_by_location.values.last },
+  root_field_location_selector: ->(field_name, locations) { locations.last },
 )
 ```
 
@@ -27,6 +28,8 @@ Constructor arguments:
 - **`deprecation_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging element deprecation strings from across locations.
 
 - **`directive_kwarg_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging directive keyword arguments from across locations.
+
+- **`root_field_location_selector:`** _optional_, selects a default routing location for root fields with multiple locations. Use this to prioritize sending root fields to their primary data sources (only applies while routing the root operation scope). This handler receives a root field name and an array of possible locations, and should return the prioritized location. The last location is used by default.
 
 #### Value merger functions
 

--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -58,9 +58,7 @@ module GraphQL
         def fetch(ops)
           origin_sets_by_operation = ops.each_with_object({}) do |op, memo|
             origin_set = op["insertion_path"].reduce([@executor.data]) do |set, path_segment|
-              mapped = set.flat_map { |obj| obj && obj[path_segment] }
-              mapped.compact!
-              mapped
+              set.flat_map { |obj| obj && obj[path_segment] }.tap(&:compact!)
             end
 
             if op["type_condition"]

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -39,10 +39,8 @@ module GraphQL
 
           selections_by_location = @request.operation.selections.each_with_object({}) do |node, memo|
             locations = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name] || SUPERGRAPH_LOCATIONS
-
-            # root fields currently just delegate to the last location that defined them; this should probably be smarter
-            memo[locations.last] ||= []
-            memo[locations.last] << node
+            memo[locations.first] ||= []
+            memo[locations.first] << node
           end
 
           selections_by_location.each do |location, selections|
@@ -53,8 +51,7 @@ module GraphQL
           parent_type = @supergraph.schema.mutation
 
           location_groups = @request.operation.selections.each_with_object([]) do |node, memo|
-            # root fields currently just delegate to the last location that defined them; this should probably be smarter
-            next_location = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name].last
+            next_location = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name].first
 
             if memo.none? || memo.last[:location] != next_location
               memo << { location: next_location, selections: [] }

--- a/test/graphql/stitching/composer/merge_root_objects_test.rb
+++ b/test/graphql/stitching/composer/merge_root_objects_test.rb
@@ -60,4 +60,26 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
       compose_definitions({ "a" => a }, { mutation_name: "Boom" })
     end
   end
+
+  def test_prioritizes_last_root_field_location_by_default
+    a = "type Query { f:String } type Mutation { f:String }"
+    b = "type Query { f:String } type Mutation { f:String }"
+
+    delegation_map = compose_definitions({ "a" => a, "b" => b }).fields
+
+    assert_equal ["b", "a"], delegation_map["Query"]["f"]
+    assert_equal ["b", "a"], delegation_map["Mutation"]["f"]
+  end
+
+  def test_prioritizes_root_field_location_selector_choice
+    a = "type Query { f:String } type Mutation { f:String }"
+    b = "type Query { f:String } type Mutation { f:String }"
+
+    delegation_map = compose_definitions({ "a" => a, "b" => b }, {
+      root_field_location_selector: ->(field_name, locations) { "a" }
+    }).fields
+
+    assert_equal ["a", "b"], delegation_map["Query"]["f"]
+    assert_equal ["a", "b"], delegation_map["Mutation"]["f"]
+  end
 end


### PR DESCRIPTION
Adds a root field location selector function to `Composer` options:

```ruby
root_field_location_selector: ->(field_name, locations) { locations.last }
```

This allows a prioritized location to be selected for each root field with multiple locations.