### PR TITLE
More handling of introspection types

### DIFF
--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -251,7 +251,7 @@ module GraphQL
 
         if @data && @data.length > 0
           result["data"] = raw ? @data : GraphQL::Stitching::Shaper.new(
-            schema: @supergraph.schema,
+            supergraph: @supergraph,
             request: @request,
           ).perform!(@data)
         end

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -175,7 +175,7 @@ module GraphQL
               next
             end
 
-            field_type = @supergraph.cached_schema_fields(parent_type.graphql_name)[node.name].type.unwrap
+            field_type = @supergraph.memoized_schema_fields(parent_type.graphql_name)[node.name].type.unwrap
             extract_node_variables(node, locale_variables)
 
             if Util.is_leaf_type?(field_type)
@@ -191,7 +191,7 @@ module GraphQL
           when GraphQL::Language::Nodes::InlineFragment
             next unless @supergraph.locations_by_type[node.type.name].include?(current_location)
 
-            fragment_type = @supergraph.cached_schema_types[node.type.name]
+            fragment_type = @supergraph.memoized_schema_types[node.type.name]
             selection_set = extract_locale_selections(current_location, fragment_type, node.selections, insertion_path, after_key, locale_variables)
             locale_selections << node.merge(selections: selection_set)
             implements_fragments = true
@@ -200,7 +200,7 @@ module GraphQL
             fragment = @request.fragment_definitions[node.name]
             next unless @supergraph.locations_by_type[fragment.type.name].include?(current_location)
 
-            fragment_type = @supergraph.cached_schema_types[fragment.type.name]
+            fragment_type = @supergraph.memoized_schema_types[fragment.type.name]
             selection_set = extract_locale_selections(current_location, fragment_type, fragment.selections, insertion_path, after_key, locale_variables)
             locale_selections << GraphQL::Language::Nodes::InlineFragment.new(type: fragment.type, selections: selection_set)
             implements_fragments = true
@@ -357,7 +357,7 @@ module GraphQL
         end
 
         if expanded_selections
-          @supergraph.cached_schema_possible_types(parent_type.graphql_name).each do |possible_type|
+          @supergraph.memoized_schema_possible_types(parent_type.graphql_name).each do |possible_type|
             next unless @supergraph.locations_by_type[possible_type.graphql_name].include?(current_location)
 
             type_name = GraphQL::Language::Nodes::TypeName.new(name: possible_type.graphql_name)
@@ -374,7 +374,7 @@ module GraphQL
         @operations_by_grouping.each do |_grouping, op|
           next unless op.boundary
 
-          boundary_type = @supergraph.cached_schema_types[op.boundary["type_name"]]
+          boundary_type = @supergraph.memoized_schema_types[op.boundary["type_name"]]
           next unless boundary_type.kind.abstract?
           next if boundary_type == op.parent_type
 

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -175,7 +175,7 @@ module GraphQL
               next
             end
 
-            field_type = @supergraph.cached_fields_for_schema_type(parent_type.graphql_name)[node.name].type.unwrap
+            field_type = @supergraph.cached_schema_fields(parent_type.graphql_name)[node.name].type.unwrap
             extract_node_variables(node, locale_variables)
 
             if Util.is_leaf_type?(field_type)
@@ -357,7 +357,7 @@ module GraphQL
         end
 
         if expanded_selections
-          @supergraph.schema.possible_types(parent_type).each do |possible_type|
+          @supergraph.cached_schema_possible_types(parent_type.graphql_name).each do |possible_type|
             next unless @supergraph.locations_by_type[possible_type.graphql_name].include?(current_location)
 
             type_name = GraphQL::Language::Nodes::TypeName.new(name: possible_type.graphql_name)

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -37,10 +37,11 @@ module GraphQL
         when "query"
           parent_type = @supergraph.schema.query
 
-          selections_by_location = @request.operation.selections.each_with_object({}) do |node, memo|
+          selections_by_location = {}
+          each_selection_in_type(parent_type, @request.operation.selections) do |node|
             locations = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name] || SUPERGRAPH_LOCATIONS
-            memo[locations.first] ||= []
-            memo[locations.first] << node
+            selections_by_location[locations.first] ||= []
+            selections_by_location[locations.first] << node
           end
 
           selections_by_location.each do |location, selections|
@@ -50,14 +51,15 @@ module GraphQL
         when "mutation"
           parent_type = @supergraph.schema.mutation
 
-          location_groups = @request.operation.selections.each_with_object([]) do |node, memo|
+          location_groups = []
+          each_selection_in_type(parent_type, @request.operation.selections) do |node|
             next_location = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name].first
 
-            if memo.none? || memo.last[:location] != next_location
-              memo << { location: next_location, selections: [] }
+            if location_groups.none? || location_groups.last[:location] != next_location
+              location_groups << { location: next_location, selections: [] }
             end
 
-            memo.last[:selections] << node
+            location_groups.last[:selections] << node
           end
 
           location_groups.reduce(0) do |after_key, group|
@@ -72,6 +74,27 @@ module GraphQL
 
         else
           raise "Invalid operation type."
+        end
+      end
+
+      def each_selection_in_type(parent_type, input_selections, &block)
+        input_selections.each do |node|
+          case node
+          when GraphQL::Language::Nodes::Field
+            yield(node)
+
+          when GraphQL::Language::Nodes::InlineFragment
+            next unless parent_type.graphql_name == node.type.name
+            each_selection_in_type(parent_type, node.selections, &block)
+
+          when GraphQL::Language::Nodes::FragmentSpread
+            fragment = @request.fragment_definitions[node.name]
+            next unless parent_type.graphql_name == fragment.type.name
+            each_selection_in_type(parent_type, fragment.selections, &block)
+
+          else
+            raise "Unexpected node of type #{node.class.name} in selection set."
+          end
         end
       end
 
@@ -98,11 +121,8 @@ module GraphQL
         # groupings coalesce similar operation parameters into a single operation
         # multiple operations per service may still occur with different insertion points,
         # but those will get query-batched together during execution.
-        grouping = String.new
-        grouping << after_key.to_s << "/" << location << "/" << parent_type.graphql_name
-        grouping = insertion_path.reduce(grouping) do |memo, segment|
-          memo << "/" << segment
-        end
+        grouping = String.new("#{after_key}/#{location}/#{parent_type.graphql_name}")
+        insertion_path.each { grouping << "/#{_1}" }
 
         if op = @operations_by_grouping[grouping]
           op.selections.concat(locale_selections)
@@ -155,7 +175,7 @@ module GraphQL
               next
             end
 
-            field_type = Util.type_for_field_node(@supergraph.schema, parent_type, node).unwrap
+            field_type = @supergraph.cached_fields_for_schema_type(parent_type.graphql_name)[node.name].type.unwrap
             extract_node_variables(node, locale_variables)
 
             if Util.is_leaf_type?(field_type)
@@ -171,7 +191,7 @@ module GraphQL
           when GraphQL::Language::Nodes::InlineFragment
             next unless @supergraph.locations_by_type[node.type.name].include?(current_location)
 
-            fragment_type = @supergraph.schema.types[node.type.name]
+            fragment_type = @supergraph.cached_schema_types[node.type.name]
             selection_set = extract_locale_selections(current_location, fragment_type, node.selections, insertion_path, after_key, locale_variables)
             locale_selections << node.merge(selections: selection_set)
             implements_fragments = true
@@ -180,7 +200,7 @@ module GraphQL
             fragment = @request.fragment_definitions[node.name]
             next unless @supergraph.locations_by_type[fragment.type.name].include?(current_location)
 
-            fragment_type = @supergraph.schema.types[fragment.type.name]
+            fragment_type = @supergraph.cached_schema_types[fragment.type.name]
             selection_set = extract_locale_selections(current_location, fragment_type, fragment.selections, insertion_path, after_key, locale_variables)
             locale_selections << GraphQL::Language::Nodes::InlineFragment.new(type: fragment.type, selections: selection_set)
             implements_fragments = true
@@ -354,7 +374,7 @@ module GraphQL
         @operations_by_grouping.each do |_grouping, op|
           next unless op.boundary
 
-          boundary_type = @supergraph.schema.types[op.boundary["type_name"]]
+          boundary_type = @supergraph.cached_schema_types[op.boundary["type_name"]]
           next unless boundary_type.kind.abstract?
           next if boundary_type == op.parent_type
 

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -31,7 +31,7 @@ module GraphQL
               raw_object[field_name] = @root_type.graphql_name if is_root_typename
             end
 
-            node_type = @supergraph.cached_schema_fields(parent_type.graphql_name)[node.name].type
+            node_type = @supergraph.memoized_schema_fields(parent_type.graphql_name)[node.name].type
             named_type = node_type.unwrap
 
             raw_object[field_name] = if node_type.list?
@@ -45,7 +45,7 @@ module GraphQL
             return nil if raw_object[field_name].nil? && node_type.non_null?
 
           when GraphQL::Language::Nodes::InlineFragment
-            fragment_type = @supergraph.cached_schema_types[node.type.name]
+            fragment_type = @supergraph.memoized_schema_types[node.type.name]
             next unless typename_in_type?(typename, fragment_type)
 
             result = resolve_object_scope(raw_object, fragment_type, node.selections, typename)
@@ -53,7 +53,7 @@ module GraphQL
 
           when GraphQL::Language::Nodes::FragmentSpread
             fragment = @request.fragment_definitions[node.name]
-            fragment_type = @supergraph.cached_schema_types[fragment.type.name]
+            fragment_type = @supergraph.memoized_schema_types[fragment.type.name]
             next unless typename_in_type?(typename, fragment_type)
 
             result = resolve_object_scope(raw_object, fragment_type, fragment.selections, typename)
@@ -114,7 +114,7 @@ module GraphQL
       def typename_in_type?(typename, type)
         return true if type.graphql_name == typename
 
-        type.kind.abstract? && @supergraph.cached_schema_possible_types(type.graphql_name).any? do |t|
+        type.kind.abstract? && @supergraph.memoized_schema_possible_types(type.graphql_name).any? do |t|
           t.graphql_name == typename
         end
       end

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -46,7 +46,8 @@ module GraphQL
         @boundaries = boundaries
         @possible_keys_by_type = {}
         @possible_keys_by_type_and_location = {}
-        @cached_fields_by_schema_type = {}
+        @cached_schema_possible_types = {}
+        @cached_schema_fields = {}
 
         # add introspection types into the fields mapping
         @locations_by_type_and_field = INTROSPECTION_TYPES.each_with_object(fields) do |type_name, memo|
@@ -82,14 +83,16 @@ module GraphQL
         }
       end
 
-      # a stable cache for the compiled schema.types hash
       def cached_schema_types
         @cached_schema_types ||= @schema.types
       end
 
-      # a stable cache for the compiled member.fields hash of each type
-      def cached_fields_for_schema_type(type_name)
-        @cached_fields_by_schema_type[type_name] ||= begin
+      def cached_schema_possible_types(type_name)
+        @cached_schema_possible_types[type_name] ||= @schema.possible_types(cached_schema_types[type_name])
+      end
+
+      def cached_schema_fields(type_name)
+        @cached_schema_fields[type_name] ||= begin
           fields = cached_schema_types[type_name].fields
           fields["__typename"] = @schema.introspection_system.dynamic_field(name: "__typename")
 

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -46,8 +46,8 @@ module GraphQL
         @boundaries = boundaries
         @possible_keys_by_type = {}
         @possible_keys_by_type_and_location = {}
-        @cached_schema_possible_types = {}
-        @cached_schema_fields = {}
+        @memoized_schema_possible_types = {}
+        @memoized_schema_fields = {}
 
         # add introspection types into the fields mapping
         @locations_by_type_and_field = INTROSPECTION_TYPES.each_with_object(fields) do |type_name, memo|
@@ -83,17 +83,17 @@ module GraphQL
         }
       end
 
-      def cached_schema_types
-        @cached_schema_types ||= @schema.types
+      def memoized_schema_types
+        @memoized_schema_types ||= @schema.types
       end
 
-      def cached_schema_possible_types(type_name)
-        @cached_schema_possible_types[type_name] ||= @schema.possible_types(cached_schema_types[type_name])
+      def memoized_schema_possible_types(type_name)
+        @memoized_schema_possible_types[type_name] ||= @schema.possible_types(memoized_schema_types[type_name])
       end
 
-      def cached_schema_fields(type_name)
-        @cached_schema_fields[type_name] ||= begin
-          fields = cached_schema_types[type_name].fields
+      def memoized_schema_fields(type_name)
+        @memoized_schema_fields[type_name] ||= begin
+          fields = memoized_schema_types[type_name].fields
           fields["__typename"] = @schema.introspection_system.dynamic_field(name: "__typename")
 
           if type_name == @schema.query.graphql_name

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -37,19 +37,6 @@ module GraphQL
         structure
       end
 
-      # gets a named type for a field node, including hidden root introspections
-      def self.type_for_field_node(schema, parent_type, node)
-        if parent_type == schema.query
-          case node.name
-          when "__schema"
-            return schema.types["__Schema"]
-          when "__type"
-            return schema.types["__Type"]
-          end
-        end
-        parent_type.fields[node.name].type
-      end
-
       # expands interfaces and unions to an array of their memberships
       # like `schema.possible_types`, but includes child interfaces
       def self.expand_abstract_type(schema, parent_type)

--- a/test/graphql/stitching/integration/errors_test.rb
+++ b/test/graphql/stitching/integration/errors_test.rb
@@ -10,7 +10,7 @@ describe 'GraphQL::Stitching, errors' do
       "b" => Schemas::Errors::ElementsB,
     })
 
-    @query = <<~GRAPHQL
+    @query = %|
       query($ids: [ID!]!) {
         elementsA(ids: $ids) {
           name
@@ -18,7 +18,7 @@ describe 'GraphQL::Stitching, errors' do
           year
         }
       }
-    GRAPHQL
+    |
   end
 
   def test_queries_merged_interfaces

--- a/test/graphql/stitching/integration/interfaces_test.rb
+++ b/test/graphql/stitching/integration/interfaces_test.rb
@@ -12,7 +12,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
   end
 
   def test_queries_merged_interface_via_concrete
-    query = <<~GRAPHQL
+    query = %|
       query($ids: [ID!]!) {
         bundles(ids: $ids) {
           id
@@ -25,7 +25,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
           }
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, query, { "ids" => ["10"] })
 
@@ -55,7 +55,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
   end
 
   def test_queries_merged_interface_via_full_interface
-    query = <<~GRAPHQL
+    query = %|
       query($ids: [ID!]!) {
         result: productsBuyables(ids: $ids) {
           id
@@ -63,7 +63,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
           price
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, query, { "ids" => ["1"] })
 
@@ -81,7 +81,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
   end
 
   def test_queries_merged_interface_via_partial_interface
-    query = <<~GRAPHQL
+    query = %|
       query($ids: [ID!]!) {
         result: bundlesBuyables(ids: $ids) {
           id
@@ -96,7 +96,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
           }
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, query, { "ids" => ["10"] })
 
@@ -126,7 +126,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
   end
 
   def test_queries_merged_split_interface
-    query1 = <<~GRAPHQL
+    query1 = %|
       query($ids: [ID!]!) {
         result: productsSplit(ids: $ids) {
           id
@@ -134,9 +134,9 @@ describe 'GraphQL::Stitching, merged interfaces' do
           price
         }
       }
-    GRAPHQL
+    |
 
-    query2 = <<~GRAPHQL
+    query2 = %|
       query($ids: [ID!]!) {
         result: bundlesSplit(ids: $ids) {
           id
@@ -144,7 +144,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
           price
         }
       }
-    GRAPHQL
+    |
 
     result1 = plan_and_execute(@supergraph, query1, { "ids" => ["100", "200"] })
     result2 = plan_and_execute(@supergraph, query2, { "ids" => ["100", "200"] })
@@ -171,7 +171,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
   end
 
   def test_merges_within_interface_fragments
-    query = <<~GRAPHQL
+    query = %|
       query($ids: [ID!]!) {
         result: nodes(ids: $ids) {
           id
@@ -180,7 +180,7 @@ describe 'GraphQL::Stitching, merged interfaces' do
           __typename
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, query, { "ids" => ["1", "100"] })
 

--- a/test/graphql/stitching/integration/introspection_test.rb
+++ b/test/graphql/stitching/integration/introspection_test.rb
@@ -86,4 +86,60 @@ describe 'GraphQL::Stitching, introspection' do
 
     assert_equal expected, result
   end
+
+  def test_handles_introspection_type_inline_fragments
+    result = plan_and_execute(@supergraph, %|
+      {
+        __typename
+        ...on __Directive { __typename }
+        ...on __EnumValue { __typename }
+        ...on __InputValue { __typename }
+        ...on __Field { __typename }
+        ...on __Schema { __typename }
+        ...on __Type { __typename }
+        product(upc: "1") {
+          ...on __Directive { __typename }
+          ...on __EnumValue { __typename }
+          ...on __InputValue { __typename }
+          ...on __Field { __typename }
+          ...on __Schema { __typename }
+          ...on __Type { __typename }
+        }
+      }
+    |)
+
+    expected = { "data" => { "__typename" => "Query", "product" => {} } }
+    assert_equal expected, result
+  end
+
+  def test_handles_introspection_type_fragment_spreads
+    result = plan_and_execute(@supergraph, %|
+      fragment DirectiveAttrs on __Directive { __typename }
+      fragment EnumValueAttrs on __EnumValue { __typename }
+      fragment InputValueAttrs on __InputValue { __typename }
+      fragment FieldAttrs on __Field { __typename }
+      fragment SchemaAttrs on __Schema { __typename }
+      fragment TypeAttrs on __Type { __typename }
+      {
+        __typename
+        ...DirectiveAttrs
+        ...EnumValueAttrs
+        ...InputValueAttrs
+        ...FieldAttrs
+        ...SchemaAttrs
+        ...TypeAttrs
+        product(upc: "1") {
+          ...DirectiveAttrs
+          ...EnumValueAttrs
+          ...InputValueAttrs
+          ...FieldAttrs
+          ...SchemaAttrs
+          ...TypeAttrs
+        }
+      }
+    |)
+
+    expected = { "data" => { "__typename" => "Query", "product" => {} } }
+    assert_equal expected, result
+  end
 end

--- a/test/graphql/stitching/shaper/grooming_test.rb
+++ b/test/graphql/stitching/shaper/grooming_test.rb
@@ -7,7 +7,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
   def test_prunes_stitching_fields
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { __typename req opt } }"),
     )
     raw = {
@@ -33,7 +33,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
   def test_adds_missing_fields
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -56,7 +56,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
   def test_grooms_through_inline_fragments
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { ... on Test { ... on Test { req opt } } } }"),
     )
     raw = {
@@ -78,13 +78,13 @@ describe "GraphQL::Stitching::Shaper, grooming" do
 
   def test_grooms_through_fragment_spreads
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
-    query = <<~GRAPHQL
+    query = %|
       query { test { ...Test2 } }
       fragment Test1 on Test { req opt }
       fragment Test2 on Test { ...Test1 }
-    GRAPHQL
+    |
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new(query),
     )
     raw = {
@@ -104,12 +104,52 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     assert_equal expected, shaper.perform!(raw)
   end
 
+  def test_renames_root_query_typenames
+    schema_sdl = "type Query { field: String }"
+    source = %|
+      fragment RootAttrs on Query { typename2: __typename }
+      query {
+        __typename
+        ...on Query { typename1: __typename }
+        ...RootAttrs
+      }
+    |
+    shaper = GraphQL::Stitching::Shaper.new(
+      supergraph: supergraph_from_schema(schema_sdl),
+      request: GraphQL::Stitching::Request.new(source),
+    )
+
+    raw = { "__typename" => "QueryRoot", "typename1" => "QueryRoot", "typename2" => "QueryRoot" }
+    expected = { "__typename" => "Query", "typename1" => "Query", "typename2" => "Query" }
+    assert_equal expected, shaper.perform!(raw)
+  end
+
+  def test_renames_root_mutation_typenames
+    schema_sdl = "type Mutation { field: String } type Query { field: String }"
+    source = %|
+      fragment RootAttrs on Mutation { typename2: __typename }
+      mutation {
+        __typename
+        ...on Mutation { typename1: __typename }
+        ...RootAttrs
+      }
+    |
+    shaper = GraphQL::Stitching::Shaper.new(
+      supergraph: supergraph_from_schema(schema_sdl),
+      request: GraphQL::Stitching::Request.new(source),
+    )
+
+    raw = { "__typename" => "MutationRoot", "typename1" => "MutationRoot", "typename2" => "MutationRoot" }
+    expected = { "__typename" => "Mutation", "typename1" => "Mutation", "typename2" => "Mutation" }
+    assert_equal expected, shaper.perform!(raw)
+  end
+
   def test_handles_introspection_types
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     schema = GraphQL::Schema.from_definition(schema_sdl)
     shaper = GraphQL::Stitching::Shaper.new(
+      supergraph: supergraph_from_schema(schema),
       request: GraphQL::Stitching::Request.new(INTROSPECTION_QUERY),
-      schema: schema,
     )
 
     raw = schema.execute(query: INTROSPECTION_QUERY).to_h

--- a/test/graphql/stitching/shaper/null_bubbling_test.rb
+++ b/test/graphql/stitching/shaper/null_bubbling_test.rb
@@ -6,7 +6,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_basic_object_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -28,7 +28,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_single_object_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -45,7 +45,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_recursive_object_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test! }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -61,7 +61,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_basic_list_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -83,7 +83,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -105,7 +105,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_required_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test!] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -124,7 +124,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_required_lists
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test!]! }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -140,7 +140,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_basic_nested_list_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test]] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -162,7 +162,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_nested_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test]] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -184,7 +184,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_nested_required_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -206,7 +206,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_for_inner_required_lists
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]!] }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -225,7 +225,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubbles_null_through_nested_required_list_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]!]! }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
     )
     raw = {
@@ -241,7 +241,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_bubble_through_inline_fragment
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new("{ test { ... on Test { ... on Test { req opt } } } }"),
     )
     raw = {
@@ -266,7 +266,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       fragment Test2 on Test { ...Test1 }
     GRAPHQL
     shaper = GraphQL::Stitching::Shaper.new(
-      schema: GraphQL::Schema.from_definition(schema_sdl),
+      supergraph: supergraph_from_schema(schema_sdl),
       request: GraphQL::Stitching::Request.new(query),
     )
     raw = {

--- a/test/graphql/stitching/util_test.rb
+++ b/test/graphql/stitching/util_test.rb
@@ -68,16 +68,6 @@ class GraphQL::Stitching::UtilTest < Minitest::Test
     assert_equal "String", Util.unwrap_non_null(field).unwrap.graphql_name
   end
 
-  def test_named_type_for_field_node_with_schema_field
-    node = GraphQL.parse("{ first }").definitions.first.selections.first
-    assert_equal "FirstObject", Util.type_for_field_node(TestSchema, TestSchema.query, node).unwrap.graphql_name
-  end
-
-  def test_named_type_for_field_node_with_introspection_field
-    node = GraphQL.parse("{ __schema }").definitions.first.selections.first
-    assert_equal "__Schema", Util.type_for_field_node(TestSchema, TestSchema.query, node).unwrap.graphql_name
-  end
-
   def test_flatten_type_structure
     expected_list1 = [
       { list: true, null: false, name: nil },

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,18 @@ def compose_definitions(locations, options={})
   GraphQL::Stitching::Composer.new(**options).perform(locations)
 end
 
+def supergraph_from_schema(schema)
+  GraphQL::Stitching::Supergraph.from_export(
+    schema: schema,
+    delegation_map: {
+      "locations" => [],
+      "fields" => {},
+      "boundaries" => {},
+    },
+    executables: {},
+  )
+end
+
 def plan_and_execute(supergraph, query, variables={}, raw: false)
   request = GraphQL::Stitching::Request.new(query, variables: variables)
 


### PR DESCRIPTION
Numerous improvements around performance and selection handling:

- Adds an intermediary cache on `supergraph` so that calls to  `schema.type` and `type.fields` are only processed once and then reused.
- Adds handling of fragments in the root selection scope.
- Adds additional handling for introspection types.