### PR TITLE
Apply static configuration without modifying schema

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -5,6 +5,7 @@ require "graphql"
 module GraphQL
   module Stitching
     EMPTY_OBJECT = {}.freeze
+    EMPTY_ARRAY = [].freeze
 
     class StitchingError < StandardError; end
 


### PR DESCRIPTION
At present, static configuration of `@stitch` directives work by adding directives into the schema and letting those get read back out into boundaries. This changes the pattern so that directives are simply read into static configuration, and boundaries build from that.