### PR TITLE
Sort directly into A* pop order

### DIFF
--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -227,9 +227,9 @@ module GraphQL
           end
 
           paths.sort! do |a, b|
-            cost_diff = a.last[:cost] - b.last[:cost]
-            cost_diff.zero? ? a.length - b.length : cost_diff
-          end.reverse!
+            cost_diff = b.last[:cost] - a.last[:cost]
+            cost_diff.zero? ? b.length - a.length : cost_diff
+          end
         end
 
         results


### PR DESCRIPTION
This was bugging me... no need to sort into the forward order and then reverse when we can just sort directly into the reverse order.