### PR TITLE
Formal structs for Plan, Op, and Boundary

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -25,11 +25,13 @@ module GraphQL
 end
 
 require_relative "stitching/supergraph"
+require_relative "stitching/boundary"
 require_relative "stitching/client"
 require_relative "stitching/composer"
 require_relative "stitching/executor"
 require_relative "stitching/http_executable"
-require_relative "stitching/planner_operation"
+require_relative "stitching/plan"
+require_relative "stitching/planner_step"
 require_relative "stitching/planner"
 require_relative "stitching/request"
 require_relative "stitching/shaper"

--- a/lib/graphql/stitching/boundary.rb
+++ b/lib/graphql/stitching/boundary.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Stitching
+    Boundary = Struct.new(
+      :location,
+      :type_name,
+      :key,
+      :field,
+      :arg,
+      :list,
+      :federation,
+      keyword_init: true
+    ) do
+      def as_json
+        {
+          location: location,
+          type_name: type_name,
+          key: key,
+          field: field,
+          arg: arg,
+          list: list,
+          federation: federation,
+        }.tap(&:compact!)
+      end
+    end
+  end
+end

--- a/lib/graphql/stitching/client.rb
+++ b/lib/graphql/stitching/client.rb
@@ -41,7 +41,7 @@ module GraphQL
           GraphQL::Stitching::Planner.new(
             supergraph: @supergraph,
             request: request,
-          ).perform.to_h
+          ).perform
         end
 
         GraphQL::Stitching::Executor.new(
@@ -76,16 +76,16 @@ module GraphQL
       def fetch_plan(request)
         if @on_cache_read
           cached_plan = @on_cache_read.call(request.digest, request.context)
-          return JSON.parse(cached_plan) if cached_plan
+          return GraphQL::Stitching::Plan.from_json(JSON.parse(cached_plan)) if cached_plan
         end
 
-        plan_json = yield
+        plan = yield
 
         if @on_cache_write
-          @on_cache_write.call(request.digest, JSON.generate(plan_json), request.context)
+          @on_cache_write.call(request.digest, JSON.generate(plan.as_json), request.context)
         end
 
-        plan_json
+        plan
       end
 
       def error_result(errors)

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -509,15 +509,15 @@ module GraphQL
               end
 
               @boundary_map[impl_type_name] ||= []
-              @boundary_map[impl_type_name] << {
-                "location" => location,
-                "type_name" => impl_type_name,
-                "key" => key_selections[0].name,
-                "field" => field_candidate.name,
-                "arg" => argument_name,
-                "list" => boundary_structure.first[:list],
-                "federation" => kwargs[:federation],
-              }.compact
+              @boundary_map[impl_type_name] << Boundary.new(
+                location: location,
+                type_name: impl_type_name,
+                key: key_selections[0].name,
+                field: field_candidate.name,
+                arg: argument_name,
+                list: boundary_structure.first[:list],
+                federation: kwargs[:federation],
+              )
             end
           end
         end

--- a/lib/graphql/stitching/composer/validate_boundaries.rb
+++ b/lib/graphql/stitching/composer/validate_boundaries.rb
@@ -32,16 +32,16 @@ module GraphQL
 
         # only one boundary allowed per type/location/key
         boundaries_by_location_and_key = boundaries.each_with_object({}) do |boundary, memo|
-          if memo.dig(boundary["location"], boundary["key"])
-            raise Composer::ValidationError, "Multiple boundary queries for `#{type.graphql_name}.#{boundary["key"]}` "\
-              "found in #{boundary["location"]}. Limit one boundary query per type and key in each location. "\
+          if memo.dig(boundary.location, boundary.key)
+            raise Composer::ValidationError, "Multiple boundary queries for `#{type.graphql_name}.#{boundary.key}` "\
+              "found in #{boundary.location}. Limit one boundary query per type and key in each location. "\
               "Abstract boundaries provide all possible types."
           end
-          memo[boundary["location"]] ||= {}
-          memo[boundary["location"]][boundary["key"]] = boundary
+          memo[boundary.location] ||= {}
+          memo[boundary.location][boundary.key] = boundary
         end
 
-        boundary_keys = boundaries.map { _1["key"] }.uniq
+        boundary_keys = boundaries.map { _1.key }.uniq
         key_only_types_by_location = candidate_types_by_location.select do |location, subschema_type|
           subschema_type.fields.keys.length == 1 && boundary_keys.include?(subschema_type.fields.keys.first)
         end

--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -11,7 +11,7 @@ module GraphQL
       def initialize(supergraph:, request:, plan:, nonblocking: false)
         @supergraph = supergraph
         @request = request
-        @queue = plan["ops"]
+        @queue = plan.ops
         @data = {}
         @errors = []
         @query_count = 0
@@ -47,8 +47,8 @@ module GraphQL
 
         @dataloader.append_job do
           tasks = @queue
-            .select { next_ordinals.include?(_1["after"]) }
-            .group_by { [_1["location"], _1["boundary"].nil?] }
+            .select { next_ordinals.include?(_1.after) }
+            .group_by { [_1.location, _1.boundary.nil?] }
             .map do |(location, root_source), ops|
               if root_source
                 @dataloader.with(RootSource, self, location).request_all(ops)

--- a/lib/graphql/stitching/executor/root_source.rb
+++ b/lib/graphql/stitching/executor/root_source.rb
@@ -12,8 +12,8 @@ module GraphQL
         op = ops.first # There should only ever be one per location at a time
 
         query_document = build_document(op, @executor.request.operation_name)
-        query_variables = @executor.request.variables.slice(*op["variables"].keys)
-        result = @executor.supergraph.execute_at_location(op["location"], query_document, query_variables, @executor.request.context)
+        query_variables = @executor.request.variables.slice(*op.variables.keys)
+        result = @executor.supergraph.execute_at_location(op.location, query_document, query_variables, @executor.request.context)
         @executor.query_count += 1
 
         @executor.data.merge!(result["data"]) if result["data"]
@@ -22,25 +22,25 @@ module GraphQL
           @executor.errors.concat(result["errors"])
         end
 
-        ops.map { op["order"] }
+        ops.map(&:step)
       end
 
       # Builds root source documents
       # "query MyOperation_1($var:VarType) { rootSelections ... }"
       def build_document(op, operation_name = nil)
         doc = String.new
-        doc << op["operation_type"]
+        doc << op.operation_type
 
         if operation_name
-          doc << " #{operation_name}_#{op["order"]}"
+          doc << " #{operation_name}_#{op.step}"
         end
 
-        if op["variables"].any?
-          variable_defs = op["variables"].map { |k, v| "$#{k}:#{v}" }.join(",")
+        if op.variables.any?
+          variable_defs = op.variables.map { |k, v| "$#{k}:#{v}" }.join(",")
           doc << "(#{variable_defs})"
         end
 
-        doc << op["selections"]
+        doc << op.selections
         doc
       end
     end

--- a/lib/graphql/stitching/plan.rb
+++ b/lib/graphql/stitching/plan.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Stitching
+    class Plan
+      Op = Struct.new(
+        :step,
+        :after,
+        :location,
+        :operation_type,
+        :selections,
+        :variables,
+        :path,
+        :if_type,
+        :boundary,
+        keyword_init: true
+      ) do
+        def as_json
+          {
+            step: step,
+            after: after,
+            location: location,
+            operation_type: operation_type,
+            selections: selections,
+            variables: variables,
+            path: path,
+            if_type: if_type,
+            boundary: boundary&.as_json
+          }.tap(&:compact!)
+        end
+      end
+
+      class << self
+        def from_json(json)
+          ops = json["ops"]
+          ops = ops.map do |op|
+            boundary = op["boundary"]
+            Op.new(
+              step: op["step"],
+              after: op["after"],
+              location: op["location"],
+              operation_type: op["operation_type"],
+              selections: op["selections"],
+              variables: op["variables"],
+              path: op["path"],
+              if_type: op["if_type"],
+              boundary: boundary ? GraphQL::Stitching::Boundary.new(**boundary) : nil,
+            )
+          end
+          new(ops: ops)
+        end
+      end
+
+      attr_reader :ops
+
+      def initialize(ops: [])
+        @ops = ops
+      end
+
+      def as_json
+        { ops: @ops.map(&:as_json) }
+      end
+    end
+  end
+end

--- a/lib/graphql/stitching/planner_step.rb
+++ b/lib/graphql/stitching/planner_step.rb
@@ -2,27 +2,27 @@
 
 module GraphQL
   module Stitching
-    class PlannerOperation
+    class PlannerStep
       LANGUAGE_PRINTER = GraphQL::Language::Printer.new
 
-      attr_reader :order, :location, :parent_type, :if_type, :operation_type, :path
+      attr_reader :index, :location, :parent_type, :if_type, :operation_type, :path
       attr_accessor :after, :selections, :variables, :boundary
 
       def initialize(
         location:,
         parent_type:,
-        order:,
+        index:,
         after: nil,
         operation_type: "query",
         selections: [],
-        variables: [],
+        variables: {},
         path: [],
         if_type: nil,
         boundary: nil
       )
         @location = location
         @parent_type = parent_type
-        @order = order
+        @index = index
         @after = after
         @operation_type = operation_type
         @selections = selections
@@ -32,31 +32,31 @@ module GraphQL
         @boundary = boundary
       end
 
-      def selection_set
+      def to_plan_op
+        GraphQL::Stitching::Plan::Op.new(
+          step: @index,
+          after: @after,
+          location: @location,
+          operation_type: @operation_type,
+          selections: rendered_selections,
+          variables: rendered_variables,
+          path: @path,
+          if_type: @if_type,
+          boundary: @boundary,
+        )
+      end
+
+      private
+
+      def rendered_selections
         op = GraphQL::Language::Nodes::OperationDefinition.new(selections: @selections)
         LANGUAGE_PRINTER.print(op).gsub!(/\s+/, " ").strip!
       end
 
-      def variable_set
+      def rendered_variables
         @variables.each_with_object({}) do |(variable_name, value_type), memo|
           memo[variable_name] = LANGUAGE_PRINTER.print(value_type)
         end
-      end
-
-      def to_h
-        data = {
-          "order" => @order,
-          "after" => @after,
-          "location" => @location,
-          "operation_type" => @operation_type,
-          "selections" => selection_set,
-          "variables" => variable_set,
-          "path" => @path,
-        }
-
-        data["if_type"] = @if_type if @if_type
-        data["boundary"] = @boundary if @boundary
-        data
       end
     end
   end

--- a/test/graphql/stitching/composer/configuration_test.rb
+++ b/test/graphql/stitching/composer/configuration_test.rb
@@ -44,22 +44,22 @@ describe 'GraphQL::Stitching::Composer, configuration' do
 
     expected_boundaries = {
       "Product" => [
-        {
-          "location" => "alpha",
-          "type_name" => "Product",
-          "field" => "productA",
-          "key" => "id",
-          "arg" => "id",
-          "list" => false,
-        },
-        {
-          "location" => "bravo",
-          "type_name" => "Product",
-          "field" => "productB",
-          "key" => "id",
-          "arg" => "key",
-          "list" => false,
-        },
+        GraphQL::Stitching::Boundary.new(
+          location: "alpha",
+          type_name: "Product",
+          field: "productA",
+          key: "id",
+          arg: "id",
+          list: false,
+        ),
+        GraphQL::Stitching::Boundary.new(
+          location: "bravo",
+          type_name: "Product",
+          field: "productB",
+          key: "id",
+          arg: "key",
+          list: false,
+        ),
       ]
     }
 

--- a/test/graphql/stitching/composer/merge_boundaries_test.rb
+++ b/test/graphql/stitching/composer/merge_boundaries_test.rb
@@ -10,8 +10,22 @@ describe 'GraphQL::Stitching::Composer, merging boundary queries' do
 
     expected_boundaries_map = {
       "Test" => [
-        { "location"=>"a", "key"=>"id", "field"=>"a", "arg"=>"id", "list"=>false, "type_name"=>"Test" },
-        { "location"=>"b", "key"=>"id", "field"=>"b", "arg"=>"ids", "list"=>true, "type_name"=>"Test" },
+        GraphQL::Stitching::Boundary.new(
+          location: "a",
+          key: "id",
+          field: "a",
+          arg: "id",
+          list: false,
+          type_name: "Test"
+        ),
+        GraphQL::Stitching::Boundary.new(
+          location: "b",
+          key: "id",
+          field: "b",
+          arg: "ids",
+          list: true,
+          type_name: "Test"
+        ),
       ],
     }
 
@@ -109,10 +123,10 @@ describe 'GraphQL::Stitching::Composer, merging boundary queries' do
   def assert_boundary(supergraph, type_name, location:, key: nil, field: nil, arg: nil)
     boundary = supergraph.boundaries[type_name].find do |b|
       conditions = []
-      conditions << (b["location"] == location)
-      conditions << (b["field"] == field) if field
-      conditions << (b["arg"] == arg) if arg
-      conditions << (b["key"] == key) if key
+      conditions << (b.location == location)
+      conditions << (b.field == field) if field
+      conditions << (b.arg == arg) if arg
+      conditions << (b.key == key) if key
       conditions.all?
     end
     assert boundary, "No boundary found for #{[location, type_name, key, field, arg].join(".")}"

--- a/test/graphql/stitching/executor/boundary_source_test.rb
+++ b/test/graphql/stitching/executor/boundary_source_test.rb
@@ -4,42 +4,42 @@ require "test_helper"
 
 describe "GraphQL::Stitching::Executor, BoundarySource" do
   def setup
-    @op1 = {
-      "order"=>2,
-      "after"=>1,
-      "location"=>"products",
-      "operation_type"=>"query",
-      "path"=>["storefronts"],
-      "if_type"=>"Storefront",
-      "selections"=>"{ name(lang:$lang) }",
-      "variables"=>{ "lang" => "String!" },
-      "boundary"=>{
-        "location"=>"products",
-        "field"=>"storefronts",
-        "arg"=>"ids",
-        "key"=>"id",
-        "list"=>true,
-        "type_name"=>"Storefront"
-      }
-    }
-    @op2 = {
-      "order"=>3,
-      "after"=>1,
-      "location"=>"products",
-      "operation_type"=>"query",
-      "path"=>["storefronts", "product"],
-      "if_type"=>"Product",
-      "selections"=>"{ price(currency:$currency) }",
-      "variables"=>{ "currency" => "Currency!" },
-      "boundary"=>{
-        "location"=>"products",
-        "field"=>"product",
-        "arg"=>"upc",
-        "key"=>"upc",
-        "list"=>false,
-        "type_name"=>"Product"
-      }
-    }
+    @op1 = GraphQL::Stitching::Plan::Op.new(
+      step: 2,
+      after: 1,
+      location: "products",
+      operation_type: "query",
+      path: ["storefronts"],
+      if_type: "Storefront",
+      selections: "{ name(lang:$lang) }",
+      variables: { "lang" => "String!" },
+      boundary: GraphQL::Stitching::Boundary.new(
+        location: "products",
+        field: "storefronts",
+        arg: "ids",
+        key: "id",
+        list: true,
+        type_name: "Storefront"
+      )
+    )
+    @op2 = GraphQL::Stitching::Plan::Op.new(
+      step: 3,
+      after: 1,
+      location: "products",
+      operation_type: "query",
+      path: ["storefronts", "product"],
+      if_type: "Product",
+      selections: "{ price(currency:$currency) }",
+      variables: { "currency" => "Currency!" },
+      boundary: GraphQL::Stitching::Boundary.new(
+        location: "products",
+        field: "product",
+        arg: "upc",
+        key: "upc",
+        list: false,
+        type_name: "Product"
+      )
+    )
 
     @source = GraphQL::Stitching::Executor::BoundarySource.new({}, "products")
     @origin_sets_by_operation = {
@@ -106,8 +106,9 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
       ]
     }
 
+    plan = GraphQL::Stitching::Plan.new(ops: [])
     mock = GraphQL::Stitching::Request.new("{}")
-    mock = GraphQL::Stitching::Executor.new(supergraph: {}, request: mock, plan: { "ops" => [] })
+    mock = GraphQL::Stitching::Executor.new(supergraph: {}, request: mock, plan: plan)
     mock.instance_variable_set(:@data, data)
 
     @source = GraphQL::Stitching::Executor::BoundarySource.new(mock, "products")

--- a/test/graphql/stitching/executor/root_source_test.rb
+++ b/test/graphql/stitching/executor/root_source_test.rb
@@ -4,17 +4,17 @@ require "test_helper"
 
 describe "GraphQL::Stitching::Executor, RootSource" do
   def setup
-    @op = {
-      "order"=>1,
-      "after"=>0,
-      "location"=>"products",
-      "operation_type"=>"query",
-      "path"=>[],
-      "if_type"=>"Storefront",
-      "selections"=>"{ storefront(id:$id) { products { _STITCH_id: id } } }",
-      "variables"=>{ "id" => "ID!" },
-      "boundary"=>nil
-    }
+    @op = GraphQL::Stitching::Plan::Op.new(
+      step: 1,
+      after: 0,
+      location: "products",
+      operation_type: "query",
+      path: [],
+      if_type: "Storefront",
+      selections: "{ storefront(id:$id) { products { _STITCH_id: id } } }",
+      variables: { "id" => "ID!" },
+      boundary: nil
+    )
 
     @source = GraphQL::Stitching::Executor::RootSource.new({}, "a")
   end

--- a/test/graphql/stitching/federation_test.rb
+++ b/test/graphql/stitching/federation_test.rb
@@ -38,7 +38,7 @@ describe "GraphQL::Stitching::Federation" do
     }
 
     result = plan_and_execute(@supergraph, query) do |plan|
-      assert_equal ["stitching", "federation", "stitching"], plan.operations.map(&:location)
+      assert_equal ["stitching", "federation", "stitching"], plan.ops.map(&:location)
     end
 
     assert_equal expected, result
@@ -77,7 +77,7 @@ describe "GraphQL::Stitching::Federation" do
     }
 
     result = plan_and_execute(@supergraph, query) do |plan|
-      assert_equal ["federation2", "federation1", "federation2"], plan.operations.map(&:location)
+      assert_equal ["federation2", "federation1", "federation2"], plan.ops.map(&:location)
     end
 
     assert_equal expected, result

--- a/test/graphql/stitching/plan_test.rb
+++ b/test/graphql/stitching/plan_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "GraphQL::Stitching::Plan" do
+  def setup
+    @boundary = GraphQL::Stitching::Boundary.new(
+      location: "products",
+      field: "storefronts",
+      arg: "ids",
+      key: "id",
+      list: true,
+      type_name: "Storefront"
+    )
+
+    @op = GraphQL::Stitching::Plan::Op.new(
+      step: 2,
+      after: 1,
+      location: "products",
+      operation_type: "query",
+      path: ["storefronts"],
+      if_type: "Storefront",
+      selections: "{ name(lang:$lang) }",
+      variables: { "lang" => "String!" },
+      boundary: @boundary,
+    )
+
+    @plan = GraphQL::Stitching::Plan.new(ops: [@op])
+
+    @serialized = {
+      "ops" => [{
+        "step" => 2,
+        "after" => 1,
+        "location" => "products",
+        "operation_type" => "query",
+        "selections" => "{ name(lang:$lang) }",
+        "variables" => {"lang" => "String!"},
+        "path" => ["storefronts"],
+        "if_type" => "Storefront",
+        "boundary" => {
+          "location" => "products",
+          "type_name" => "Storefront",
+          "key" => "id",
+          "field" => "storefronts",
+          "arg" => "ids",
+          "list" => true,
+        },
+      }],
+    }
+  end
+
+  def test_as_json_serializes_a_plan
+    assert_equal @serialized, JSON.parse(@plan.as_json.to_json)
+  end
+
+  def test_from_json_deserialized_a_plan
+    plan = GraphQL::Stitching::Plan.from_json(@serialized)
+    assert_equal [@op], plan.ops
+    assert_equal @boundary, plan.ops.first.boundary
+  end
+end

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -60,24 +60,24 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       }
     |
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "b", first.location
     assert_equal [], first.path
-    assert_equal squish_string(expected_root_selection), first.selection_set
+    assert_equal squish_string(expected_root_selection), first.selections
     assert_equal 0, first.after
     assert_nil first.if_type
     assert_nil first.boundary
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "a", second.location
     assert_equal ["buyable"], second.path
-    assert_equal "{ name price }", second.selection_set
+    assert_equal "{ name price }", second.selections
     assert_equal "products", second.boundary["field"]
     assert_equal "id", second.boundary["key"]
     assert_equal "Product", second.if_type
-    assert_equal first.order, second.after
+    assert_equal first.step, second.after
   end
 
   def test_expands_interface_selection_fragments
@@ -130,8 +130,8 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
         request: GraphQL::Stitching::Request.new(document),
       ).perform
 
-      assert_equal 2, plan.operations.length
-      assert_equal squish_string(expected_root_selection), plan.operations.first.selection_set
+      assert_equal 2, plan.ops.length
+      assert_equal squish_string(expected_root_selection), plan.ops.first.selections
     end
   end
 
@@ -165,8 +165,8 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       request: GraphQL::Stitching::Request.new(document),
     ).perform
 
-    assert_equal 2, plan.operations.length
-    assert_equal squish_string(expected_root_selection), plan.operations.first.selection_set
+    assert_equal 2, plan.ops.length
+    assert_equal squish_string(expected_root_selection), plan.ops.first.selections
   end
 
   def test_retains_interface_selections_appropraite_to_the_location
@@ -175,10 +175,10 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       request: GraphQL::Stitching::Request.new("{ products(ids:[\"1\"]) { id name price } }"),
     ).perform
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "a", first.location
     assert_equal [], first.path
-    assert_equal "{ products(ids: [\"1\"]) { id name price } }", first.selection_set
+    assert_equal "{ products(ids: [\"1\"]) { id name price } }", first.selections
     assert_equal 0, first.after
     assert_nil first.boundary
   end
@@ -231,7 +231,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       request: GraphQL::Stitching::Request.new(document),
     ).perform
 
-    assert_equal 4, plan.operations.length
+    assert_equal 4, plan.ops.length
 
     expected_root_selection = %|
       {
@@ -251,27 +251,27 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       }
     |
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "a", first.location
     assert_equal [], first.path
-    assert_equal squish_string(expected_root_selection), first.selection_set
+    assert_equal squish_string(expected_root_selection), first.selections
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "b", second.location
     assert_equal "Apple", second.if_type
     assert_equal ["fruit"], second.path
-    assert_equal "{ b }", second.selection_set
+    assert_equal "{ b }", second.selections
 
-    third = plan.operations[2]
+    third = plan.ops[2]
     assert_equal "c", third.location
     assert_equal "Apple", third.if_type
     assert_equal ["fruit"], third.path
-    assert_equal "{ c }", third.selection_set
+    assert_equal "{ c }", third.selections
 
-    fourth = plan.operations[3]
+    fourth = plan.ops[3]
     assert_equal "b", fourth.location
     assert_equal "Banana", fourth.if_type
     assert_equal ["fruit"], fourth.path
-    assert_equal "{ b }", fourth.selection_set
+    assert_equal "{ b }", fourth.selections
   end
 end

--- a/test/graphql/stitching/planner/plan_delegations_test.rb
+++ b/test/graphql/stitching/planner/plan_delegations_test.rb
@@ -53,18 +53,18 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
       request: GraphQL::Stitching::Request.new('query { alpha(id: "1") { a b } }'),
     ).perform
 
-    op1 = plan1.operations[0]
+    op1 = plan1.ops[0]
     assert_equal "alpha", op1.location
-    assert_equal %|{ alpha(id: \"1\") { a b } }|, op1.selection_set
+    assert_equal %|{ alpha(id: \"1\") { a b } }|, op1.selections
 
     plan2 = GraphQL::Stitching::Planner.new(
       supergraph: SUPERGRAPH,
       request: GraphQL::Stitching::Request.new('query { bravo(id: "1") { a b } }'),
     ).perform
 
-    op2 = plan2.operations[0]
+    op2 = plan2.ops[0]
     assert_equal "bravo", op2.location
-    assert_equal %|{ bravo(id: \"1\") { a b } }|, op2.selection_set
+    assert_equal %|{ bravo(id: \"1\") { a b } }|, op2.selections
   end
 
   def test_delegates_remote_selections_by_unique_location_then_used_location_then_highest_availability
@@ -73,20 +73,20 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
       request: GraphQL::Stitching::Request.new('query { alpha(id: "1") { a b c d e f } }'),
     ).perform
 
-    assert_equal 3, plan.operations.length
+    assert_equal 3, plan.ops.length
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "alpha", first.location
-    assert_equal %|{ alpha(id: \"1\") { a b _STITCH_id: id _STITCH_typename: __typename } }|, first.selection_set
+    assert_equal %|{ alpha(id: \"1\") { a b _STITCH_id: id _STITCH_typename: __typename } }|, first.selections
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "charlie", second.location
-    assert_equal "{ c d }", second.selection_set
-    assert_equal first.order, second.after
+    assert_equal "{ c d }", second.selections
+    assert_equal first.step, second.after
 
-    third = plan.operations[2]
+    third = plan.ops[2]
     assert_equal "echo", third.location
-    assert_equal "{ e f }", third.selection_set
-    assert_equal first.order, third.after
+    assert_equal "{ e f }", third.selections
+    assert_equal first.step, third.after
   end
 end

--- a/test/graphql/stitching/planner/plan_fragments_test.rb
+++ b/test/graphql/stitching/planner/plan_fragments_test.rb
@@ -49,25 +49,25 @@ describe "GraphQL::Stitching::Planner, fragments" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 3, plan.operations.length
+    assert_equal 3, plan.ops.length
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "base", first.location
-    assert_equal squish_string(@expected_root_query), first.selection_set
+    assert_equal squish_string(@expected_root_query), first.selections
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "exa", second.location
-    assert_equal "{ color }", second.selection_set
+    assert_equal "{ color }", second.selections
     assert_equal "AppleExtension", second.if_type
     assert_equal ["fruits", "extensions"], second.path
-    assert_equal first.order, second.after
+    assert_equal first.step, second.after
 
-    third = plan.operations[2]
+    third = plan.ops[2]
     assert_equal "exb", third.location
-    assert_equal "{ shape }", third.selection_set
+    assert_equal "{ shape }", third.selections
     assert_equal "BananaExtension", third.if_type
     assert_equal ["fruits", "extensions"], third.path
-    assert_equal first.order, third.after
+    assert_equal first.step, third.after
   end
 
   def test_plans_through_fragment_spreads
@@ -87,25 +87,25 @@ describe "GraphQL::Stitching::Planner, fragments" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 3, plan.operations.length
+    assert_equal 3, plan.ops.length
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "base", first.location
-    assert_equal squish_string(@expected_root_query), first.selection_set
+    assert_equal squish_string(@expected_root_query), first.selections
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "exa", second.location
-    assert_equal "{ color }", second.selection_set
+    assert_equal "{ color }", second.selections
     assert_equal "AppleExtension", second.if_type
     assert_equal ["fruits", "extensions"], second.path
-    assert_equal first.order, second.after
+    assert_equal first.step, second.after
 
-    third = plan.operations[2]
+    third = plan.ops[2]
     assert_equal "exb", third.location
-    assert_equal "{ shape }", third.selection_set
+    assert_equal "{ shape }", third.selections
     assert_equal "BananaExtension", third.if_type
     assert_equal ["fruits", "extensions"], third.path
-    assert_equal first.order, third.after
+    assert_equal first.step, third.after
   end
 
   def test_plans_repeat_selections_and_fragments_into_coalesced_groupings
@@ -151,19 +151,19 @@ describe "GraphQL::Stitching::Planner, fragments" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 3, plan.operations.length
+    assert_equal 3, plan.ops.length
 
-    first = plan.operations[0]
+    first = plan.ops[0]
     assert_equal "bravo", first.location
 
-    second = plan.operations[1]
+    second = plan.ops[1]
     assert_equal "alpha", second.location
     assert_equal ["namespace", "test"], second.path
-    assert_equal "{ a x y nest { a _STITCH_id: id _STITCH_typename: __typename } }", second.selection_set
+    assert_equal "{ a x y nest { a _STITCH_id: id _STITCH_typename: __typename } }", second.selections
 
-    third = plan.operations[2]
+    third = plan.ops[2]
     assert_equal "bravo", third.location
     assert_equal ["namespace", "test", "nest"], third.path
-    assert_equal "{ b }", third.selection_set
+    assert_equal "{ b }", third.selections
   end
 end

--- a/test/graphql/stitching/planner/plan_introspection_test.rb
+++ b/test/graphql/stitching/planner/plan_introspection_test.rb
@@ -15,8 +15,8 @@ describe "GraphQL::Stitching::Planner, introspection" do
       request: GraphQL::Stitching::Request.new(INTROSPECTION_QUERY, operation_name: "IntrospectionQuery"),
     ).perform
 
-    assert_equal 1, plan.operations.length
-    assert_equal "__super", plan.operations.first.location
+    assert_equal 1, plan.ops.length
+    assert_equal "__super", plan.ops.first.location
   end
 
   def test_stitches_introspection_with_other_locations
@@ -29,12 +29,12 @@ describe "GraphQL::Stitching::Planner, introspection" do
       request: GraphQL::Stitching::Request.new("{ __schema { queryType { name } } a { name } }"),
     ).perform
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
-    assert_equal "__super", plan.operations[0].location
-    assert_equal "{ __schema { queryType { name } } }", plan.operations[0].selection_set
+    assert_equal "__super", plan.ops[0].location
+    assert_equal "{ __schema { queryType { name } } }", plan.ops[0].selections
 
-    assert_equal "a", plan.operations[1].location
-    assert_equal "{ a { name } }", plan.operations[1].selection_set
+    assert_equal "a", plan.ops[1].location
+    assert_equal "{ a { name } }", plan.ops[1].selections
   end
 end

--- a/test/graphql/stitching/planner/plan_variables_test.rb
+++ b/test/graphql/stitching/planner/plan_variables_test.rb
@@ -39,13 +39,13 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
     expected_vars = { "wid" => "ID!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
 
     expected_vars = { "sid" => "ID!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[1].variable_set
+    assert_equal expected_vars, plan.ops[1].variables
   end
 
   def test_extracts_variables_from_field_directives
@@ -61,13 +61,13 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
     expected_vars = { "a" => "String!", "c" => "Int" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
 
     expected_vars = { "b" => "String", "c" => "Int" }
-    assert_equal expected_vars, plan.operations[1].variable_set
+    assert_equal expected_vars, plan.ops[1].variables
   end
 
   def test_extracts_variables_from_inline_input_objects
@@ -83,13 +83,13 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(mutation),
     ).perform
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
     expected_vars = { "wname1" => "String!", "wname2" => "String!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
 
     expected_vars = { "sname1" => "String!", "sname2" => "String!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[1].variable_set
+    assert_equal expected_vars, plan.ops[1].variables
   end
 
   def test_extracts_variables_for_input_object_fragments
@@ -105,13 +105,13 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(mutation),
     ).perform
 
-    assert_equal 2, plan.operations.length
+    assert_equal 2, plan.ops.length
 
     expected_vars = { "newWidget" => "MakeWidgetInput!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
 
     expected_vars = { "newSprocket" => "MakeSprocketInput!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[1].variable_set
+    assert_equal expected_vars, plan.ops[1].variables
   end
 
   def test_extracts_variables_from_inline_fragments
@@ -126,10 +126,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 1, plan.operations.length
+    assert_equal 1, plan.ops.length
 
     expected_vars = { "wid" => "ID!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
   end
 
   def test_extracts_variables_from_fragment_spreads
@@ -145,9 +145,9 @@ describe "GraphQL::Stitching::Planner, variables" do
       request: GraphQL::Stitching::Request.new(query),
     ).perform
 
-    assert_equal 1, plan.operations.length
+    assert_equal 1, plan.ops.length
 
     expected_vars = { "wid" => "ID!", "lang" => "String" }
-    assert_equal expected_vars, plan.operations[0].variable_set
+    assert_equal expected_vars, plan.ops[0].variables
   end
 end

--- a/test/graphql/stitching/supergraph_test.rb
+++ b/test/graphql/stitching/supergraph_test.rb
@@ -84,28 +84,28 @@ describe "GraphQL::Stitching::Supergraph" do
 
   BOUNDARIES_MAP = {
     "Manufacturer" => [
-      {
-        "location" => "manufacturers",
-        "field" => "manufacturer",
-        "arg" => "id",
-        "key" => "id",
-      },
+      GraphQL::Stitching::Boundary.new(
+        location: "manufacturers",
+        field: "manufacturer",
+        arg: "id",
+        key: "id",
+      ),
     ],
     "Product" => [
-      {
-        "location" => "products",
-        "field" => "product",
-        "arg" => "upc",
-        "key" => "upc",
-      },
+      GraphQL::Stitching::Boundary.new(
+        location: "products",
+        field: "products",
+        arg: "upc",
+        key: "upc",
+      ),
     ],
     "Storefront" => [
-      {
-        "location" => "storefronts",
-        "field" => "storefront",
-        "arg" => "id",
-        "key" => "id",
-      },
+      GraphQL::Stitching::Boundary.new(
+        location: "storefronts",
+        field: "storefronts",
+        arg: "id",
+        key: "id",
+      ),
     ],
   }
 
@@ -332,7 +332,7 @@ describe "GraphQL::Stitching::Supergraph" do
 
     def test_exports_and_restores_supergraph
       assert_equal @delegation_map["fields"], @supergraph.fields
-      assert_equal @delegation_map["boundaries"], @supergraph.boundaries
+      assert_equal @delegation_map["boundaries"], @supergraph.boundaries.map {|k, b| [k, b.map(&:as_json)] }.to_h
       assert_equal @delegation_map["locations"], @supergraph.locations
 
       supergraph_import = GraphQL::Stitching::Supergraph.from_export(

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,7 +67,7 @@ def plan_and_execute(supergraph, query, variables={}, raw: false)
   executor = GraphQL::Stitching::Executor.new(
     supergraph: supergraph,
     request: request,
-    plan: plan.to_h,
+    plan: plan,
   )
 
   result = executor.perform(raw: raw)


### PR DESCRIPTION
Big refactor to eliminate all generic hashes used in central library workflows. Plan, Op, and Boundary all become formal structures with methods and defined taxonomy. Serialization methods still allow moving these structures in and out of JSON format for caching.