### PR TITLE
Refactor Util class

### DIFF
--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -430,21 +430,21 @@ module GraphQL
             raise ComposerError, "Cannot compose mixed list structures at `#{path}`."
           end
 
-          if alt_structure.last[:name] != basis_structure.last[:name]
+          if alt_structure.last.name != basis_structure.last.name
             raise ComposerError, "Cannot compose mixed types at `#{path}`."
           end
         end
 
         type = GraphQL::Schema::BUILT_IN_TYPES.fetch(
-          basis_structure.last[:name],
-          build_type_binding(basis_structure.last[:name])
+          basis_structure.last.name,
+          build_type_binding(basis_structure.last.name)
         )
 
         basis_structure.reverse!.each_with_index do |basis, index|
           rev_index = basis_structure.length - index - 1
-          non_null = alt_structures.each_with_object([!basis[:null]]) { |s, m| m << !s[rev_index][:null] }
+          non_null = alt_structures.each_with_object([basis.non_null?]) { |s, m| m << s[rev_index].non_null? }
 
-          type = type.to_list_type if basis[:list]
+          type = type.to_list_type if basis.list?
           type = type.to_non_null_type if argument_name ? non_null.any? : non_null.all?
         end
 
@@ -515,7 +515,7 @@ module GraphQL
                 key: key_selections[0].name,
                 field: field_candidate.name,
                 arg: argument_name,
-                list: boundary_structure.first[:list],
+                list: boundary_structure.first.list?,
                 federation: kwargs[:federation],
               )
             end

--- a/lib/graphql/stitching/composer/validate_interfaces.rb
+++ b/lib/graphql/stitching/composer/validate_interfaces.rb
@@ -32,12 +32,12 @@ module GraphQL
               interface_type_structure.each_with_index do |interface_struct, index|
                 possible_struct = possible_type_structure[index]
 
-                if possible_struct[:name] != interface_struct[:name]
+                if possible_struct.name != interface_struct.name
                   raise Composer::ValidationError, "Incompatible named types between field #{possible_type.graphql_name}.#{field_name} of type "\
                     "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end
 
-                if possible_struct[:null] && !interface_struct[:null]
+                if possible_struct.null? && interface_struct.non_null?
                   raise Composer::ValidationError, "Incompatible nullability between field #{possible_type.graphql_name}.#{field_name} of type "\
                     "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -3,54 +3,65 @@
 module GraphQL
   module Stitching
     class Util
-      # specifies if a type is a primitive leaf value
-      def self.is_leaf_type?(type)
-        type.kind.scalar? || type.kind.enum?
+      TypeStructure = Struct.new(:list, :null, :name, keyword_init: true) do
+        alias_method :list?, :list
+        alias_method :null?, :null
+
+        def non_null?
+          !null
+        end
       end
 
-      # strips non-null wrappers from a type
-      def self.unwrap_non_null(type)
-        type = type.of_type while type.non_null?
-        type
-      end
+      class << self
+        # specifies if a type is a primitive leaf value
+        def is_leaf_type?(type)
+          type.kind.scalar? || type.kind.enum?
+        end
 
-      # builds a single-dimensional representation of a wrapped type structure
-      def self.flatten_type_structure(type)
-        structure = []
+        # strips non-null wrappers from a type
+        def unwrap_non_null(type)
+          type = type.of_type while type.non_null?
+          type
+        end
 
-        while type.list?
-          structure << {
-            list: true,
+        # builds a single-dimensional representation of a wrapped type structure
+        def flatten_type_structure(type)
+          structure = []
+
+          while type.list?
+            structure << TypeStructure.new(
+              list: true,
+              null: !type.non_null?,
+              name: nil,
+            )
+
+            type = unwrap_non_null(type).of_type
+          end
+
+          structure << TypeStructure.new(
+            list: false,
             null: !type.non_null?,
-            name: nil,
-          }
+            name: type.unwrap.graphql_name,
+          )
 
-          type = unwrap_non_null(type).of_type
+          structure
         end
 
-        structure << {
-          list: false,
-          null: !type.non_null?,
-          name: type.unwrap.graphql_name,
-        }
+        # expands interfaces and unions to an array of their memberships
+        # like `schema.possible_types`, but includes child interfaces
+        def expand_abstract_type(schema, parent_type)
+          return [] unless parent_type.kind.abstract?
+          return parent_type.possible_types if parent_type.kind.union?
 
-        structure
-      end
-
-      # expands interfaces and unions to an array of their memberships
-      # like `schema.possible_types`, but includes child interfaces
-      def self.expand_abstract_type(schema, parent_type)
-        return [] unless parent_type.kind.abstract?
-        return parent_type.possible_types if parent_type.kind.union?
-
-        result = []
-        schema.types.values.each do |type|
-          next unless type <= GraphQL::Schema::Interface && type != parent_type
-          next unless type.interfaces.include?(parent_type)
-          result << type
-          result.push(*expand_abstract_type(schema, type)) if type.kind.interface?
+          result = []
+          schema.types.values.each do |type|
+            next unless type <= GraphQL::Schema::Interface && type != parent_type
+            next unless type.interfaces.include?(parent_type)
+            result << type
+            result.push(*expand_abstract_type(schema, type)) if type.kind.interface?
+          end
+          result.uniq
         end
-        result.uniq
       end
     end
   end

--- a/test/graphql/stitching/util_test.rb
+++ b/test/graphql/stitching/util_test.rb
@@ -70,28 +70,28 @@ class GraphQL::Stitching::UtilTest < Minitest::Test
 
   def test_flatten_type_structure
     expected_list1 = [
-      { list: true, null: false, name: nil },
-      { list: false, null: true, name: "String" },
+      Util::TypeStructure.new(list: true, null: false, name: nil),
+      Util::TypeStructure.new(list: false, null: true, name: "String"),
     ]
     assert_equal expected_list1, Util.flatten_type_structure(field_type("list1"))
 
     expected_list2 = [
-      { list: true, null: true, name: nil },
-      { list: false, null: false, name: "String" },
+      Util::TypeStructure.new(list: true, null: true, name: nil),
+      Util::TypeStructure.new(list: false, null: false, name: "String"),
     ]
     assert_equal expected_list2, Util.flatten_type_structure(field_type("list2"))
 
     expected_list3 = [
-      { list: true, null: true, name: nil },
-      { list: true, null: false, name: nil },
-      { list: false, null: true, name: "Int" },
+      Util::TypeStructure.new(list: true, null: true, name: nil),
+      Util::TypeStructure.new(list: true, null: false, name: nil),
+      Util::TypeStructure.new(list: false, null: true, name: "Int"),
     ]
     assert_equal expected_list3, Util.flatten_type_structure(field_type("list3"))
 
     expected_list4 = [
-      { list: true, null: false, name: nil },
-      { list: true, null: true, name: nil },
-      { list: false, null: false, name: "Int" },
+      Util::TypeStructure.new(list: true, null: false, name: nil),
+      Util::TypeStructure.new(list: true, null: true, name: nil),
+      Util::TypeStructure.new(list: false, null: false, name: "Int"),
     ]
     assert_equal expected_list4, Util.flatten_type_structure(field_type("list4"))
   end


### PR DESCRIPTION
Refactors `Util` class structure and turns type structure definitions into formal structs.