### PR TITLE
New skip/include handling

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -6,6 +6,7 @@ module GraphQL
   module Stitching
     EMPTY_OBJECT = {}.freeze
     EMPTY_ARRAY = [].freeze
+    TYPENAME_NODE = GraphQL::Language::Nodes::Field.new(alias: "_STITCH_typename", name: "__typename")
 
     class StitchingError < StandardError; end
 
@@ -34,6 +35,7 @@ require_relative "stitching/plan"
 require_relative "stitching/planner_step"
 require_relative "stitching/planner"
 require_relative "stitching/request"
+require_relative "stitching/skip_include"
 require_relative "stitching/shaper"
 require_relative "stitching/util"
 require_relative "stitching/version"

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -4,7 +4,6 @@ module GraphQL
   module Stitching
     class Planner
       SUPERGRAPH_LOCATIONS = [Supergraph::LOCATION].freeze
-      TYPENAME_NODE = GraphQL::Language::Nodes::Field.new(alias: "_STITCH_typename", name: "__typename")
       ROOT_INDEX = 0
 
       def initialize(supergraph:, request:)
@@ -269,7 +268,7 @@ module GraphQL
         # B.4) Add a `__typename` selection to abstracts and concrete types that implement
         # fragments so that resolved type information is available during execution.
         if requires_typename
-          locale_selections << TYPENAME_NODE
+          locale_selections << GraphQL::Stitching::TYPENAME_NODE
         end
 
         if remote_selections
@@ -292,13 +291,13 @@ module GraphQL
                 case selection.alias
                 when foreign_key
                   has_key = true
-                when TYPENAME_NODE.alias
+                when GraphQL::Stitching::TYPENAME_NODE.alias
                   has_typename = true
                 end
               end
 
               parent_selections << GraphQL::Language::Nodes::Field.new(alias: foreign_key, name: boundary.key) unless has_key
-              parent_selections << TYPENAME_NODE unless has_typename
+              parent_selections << GraphQL::Stitching::TYPENAME_NODE unless has_typename
 
               # E.2) Add a planner operation for each new entrypoint location.
               location = boundary.location

--- a/lib/graphql/stitching/planner_step.rb
+++ b/lib/graphql/stitching/planner_step.rb
@@ -3,7 +3,7 @@
 module GraphQL
   module Stitching
     class PlannerStep
-      LANGUAGE_PRINTER = GraphQL::Language::Printer.new
+      GRAPHQL_PRINTER = GraphQL::Language::Printer.new
 
       attr_reader :index, :location, :parent_type, :if_type, :operation_type, :path
       attr_accessor :after, :selections, :variables, :boundary
@@ -50,12 +50,12 @@ module GraphQL
 
       def rendered_selections
         op = GraphQL::Language::Nodes::OperationDefinition.new(selections: @selections)
-        LANGUAGE_PRINTER.print(op).gsub!(/\s+/, " ").strip!
+        GRAPHQL_PRINTER.print(op).gsub!(/\s+/, " ").strip!
       end
 
       def rendered_variables
         @variables.each_with_object({}) do |(variable_name, value_type), memo|
-          memo[variable_name] = LANGUAGE_PRINTER.print(value_type)
+          memo[variable_name] = GRAPHQL_PRINTER.print(value_type)
         end
       end
     end

--- a/lib/graphql/stitching/skip_include.rb
+++ b/lib/graphql/stitching/skip_include.rb
@@ -67,7 +67,7 @@ module GraphQL
 
         def assess_condition(arg, variables)
           if arg.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
-            variables[arg.value.name]
+            variables[arg.value.name] || variables[arg.value.name.to_sym]
           else
             arg.value
           end

--- a/lib/graphql/stitching/skip_include.rb
+++ b/lib/graphql/stitching/skip_include.rb
@@ -4,6 +4,9 @@ module GraphQL
   module Stitching
     class SkipInclude
       class << self
+        # Faster implementation of an AST visitor for prerendering
+        # @skip and @include conditional directives into a document.
+        # This avoids unnecessary planning steps, and prepares result shaping.
         def render(document, variables)
           changed = false
           definitions = document.definitions.map do |original_definition|

--- a/lib/graphql/stitching/skip_include.rb
+++ b/lib/graphql/stitching/skip_include.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Stitching
+    class SkipInclude
+      class << self
+        def render(document, variables)
+          changed = false
+          definitions = document.definitions.map do |original_definition|
+            definition = render_node(original_definition, variables)
+            changed ||= definition.object_id != original_definition.object_id
+            definition
+          end
+
+          return document.merge(definitions: definitions), changed
+        end
+
+        private
+
+        def render_node(parent_node, variables)
+          changed = false
+          filtered_selections = parent_node.selections.filter_map do |original_node|
+            node = prune_node(original_node, variables)
+            if node.nil?
+              changed = true
+              next nil
+            end
+
+            node = render_node(node, variables) if node.selections.any?
+            changed ||= node.object_id != original_node.object_id
+            node
+          end
+
+          if filtered_selections.none?
+            filtered_selections << GraphQL::Stitching::TYPENAME_NODE
+          end
+
+          if changed
+            parent_node.merge(selections: filtered_selections)
+          else
+            parent_node
+          end
+        end
+
+        def prune_node(node, variables)
+          return node unless node.directives.any?
+
+          delete_node = false
+          filtered_directives = node.directives.reject do |directive|
+            if directive.name == "skip"
+              delete_node = assess_condition(directive.arguments.first, variables)
+              true
+            elsif directive.name == "include"
+              delete_node = !assess_condition(directive.arguments.first, variables)
+              true
+            end
+          end
+
+          if delete_node
+            nil
+          elsif filtered_directives.length != node.directives.length
+            node.merge(directives: filtered_directives)
+          else
+            node
+          end
+        end
+
+        def assess_condition(arg, variables)
+          if arg.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+            variables[arg.value.name]
+          else
+            arg.value
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/graphql/stitching/skip_include_test.rb
+++ b/test/graphql/stitching/skip_include_test.rb
@@ -3,19 +3,116 @@
 require "test_helper"
 
 describe "GraphQL::Stitching::SkipInclude" do
-  QUERY = "query First {
-    alpha @include(if: false)
-    bravo @skip(if: false) {
-      charlie @skip(if: true)
-    }
-  }
-  fragment Boo on Sfoo {
-    soo
-  }"
+  def test_omits_statically_skipped_nodes
+    render_skip_include "query {
+      a {
+        a
+        b @skip(if: true)
+        c @include(if: false)
+      }
+      b @skip(if: true)
+      c @include(if: false)
+    }"
 
-  def test_builds_with_pre_parsed_ast
-    document = GraphQL.parse(QUERY)
-    result, changed = GraphQL::Stitching::SkipInclude.render(document, {})
-    puts GraphQL::Language::Printer.new.print(result)
+    assert changed?
+    assert_result "query {
+      a { a }
+    }"
+  end
+
+  def test_removes_conditional_directives_from_kept_nodes
+    render_skip_include "query {
+      a {
+        a
+        b @skip(if: false)
+        c @include(if: true)
+      }
+      b @skip(if: false)
+      c @include(if: true)
+    }"
+
+    assert changed?
+    assert_result "query {
+      a { a b c }
+      b
+      c
+    }"
+  end
+
+  def test_omits_nodes_skipped_using_variables
+    render_skip_include "query($skip: Boolean!, $include: Boolean!) {
+      a {
+        a
+        b @skip(if: $skip)
+        c @include(if: $include)
+      }
+      b @skip(if: $include)
+      c @include(if: $skip)
+    }", {
+      "skip" => true,
+      "include" => false,
+    }
+
+    assert changed?
+    assert_result "query($skip: Boolean!, $include: Boolean!) {
+      a { a }
+      b
+      c
+    }"
+  end
+
+  def test_variables_may_reference_symbol_keys
+    render_skip_include "query($skip: Boolean!, $include: Boolean!) {
+      a {
+        a
+        b @skip(if: $skip)
+        c @include(if: $include)
+      }
+    }", {
+      skip: true,
+      include: false,
+    }
+
+    assert changed?
+    assert_result "query($skip: Boolean!, $include: Boolean!) {
+      a { a }
+    }"
+  end
+
+  def test_omitted_nodes_leaving_an_empty_scope_add_typename
+    render_skip_include "query {
+      a {
+        b @skip(if: true)
+        c @include(if: false)
+      }
+    }"
+
+    assert changed?
+    assert_result "query {
+      a { _STITCH_typename: __typename }
+    }"
+  end
+
+  def test_lacking_conditionals_produces_no_changes
+    render_skip_include "query {
+      a { b c }
+    }"
+
+    assert !changed?
+  end
+
+  private
+
+  def render_skip_include(source, variables = {})
+    @source = source
+    @result, @changed = GraphQL::Stitching::SkipInclude.render(GraphQL.parse(@source), variables)
+  end
+
+  def assert_result(result)
+    assert_equal squish_string(result), squish_string(GraphQL::Language::Printer.new.print(@result))
+  end
+
+  def changed?
+    @changed
   end
 end

--- a/test/graphql/stitching/skip_include_test.rb
+++ b/test/graphql/stitching/skip_include_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "GraphQL::Stitching::SkipInclude" do
+  QUERY = "query First {
+    alpha @include(if: false)
+    bravo @skip(if: false) {
+      charlie @skip(if: true)
+    }
+  }
+  fragment Boo on Sfoo {
+    soo
+  }"
+
+  def test_builds_with_pre_parsed_ast
+    document = GraphQL.parse(QUERY)
+    result, changed = GraphQL::Stitching::SkipInclude.render(document, {})
+    puts GraphQL::Language::Printer.new.print(result)
+  end
+end


### PR DESCRIPTION
Replaces the skip/include visitor for a much lighter weight rendering pass. Also assures that scopes resolving with no child nodes include a `__typename` selection.