### PR TITLE
Formalize selection hints

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -6,7 +6,6 @@ module GraphQL
   module Stitching
     EMPTY_OBJECT = {}.freeze
     EMPTY_ARRAY = [].freeze
-    TYPENAME_NODE = GraphQL::Language::Nodes::Field.new(alias: "_STITCH_typename", name: "__typename")
 
     class StitchingError < StandardError; end
 
@@ -35,7 +34,8 @@ require_relative "stitching/plan"
 require_relative "stitching/planner_step"
 require_relative "stitching/planner"
 require_relative "stitching/request"
-require_relative "stitching/skip_include"
+require_relative "stitching/selection_hint"
 require_relative "stitching/shaper"
+require_relative "stitching/skip_include"
 require_relative "stitching/util"
 require_relative "stitching/version"

--- a/lib/graphql/stitching/executor/boundary_source.rb
+++ b/lib/graphql/stitching/executor/boundary_source.rb
@@ -16,7 +16,7 @@ module GraphQL
 
           if op.if_type
             # operations planned around unused fragment conditions should not trigger requests
-            origin_set.select! { _1["_STITCH_typename"] == op.if_type }
+            origin_set.select! { _1[SelectionHint.typename_key] == op.if_type }
           end
 
           memo[op] = origin_set if origin_set.any?
@@ -86,9 +86,9 @@ module GraphQL
       end
 
       def build_key(key, origin_obj, federation: false)
-        key_value = JSON.generate(origin_obj["_STITCH_#{key}"])
+        key_value = JSON.generate(origin_obj[SelectionHint.key(key)])
         if federation
-          "{ __typename: \"#{origin_obj["_STITCH_typename"]}\", #{key}: #{key_value} }"
+          "{ __typename: \"#{origin_obj[SelectionHint.typename_key]}\", #{key}: #{key_value} }"
         else
           key_value
         end

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -268,7 +268,7 @@ module GraphQL
         # B.4) Add a `__typename` selection to abstracts and concrete types that implement
         # fragments so that resolved type information is available during execution.
         if requires_typename
-          locale_selections << GraphQL::Stitching::TYPENAME_NODE
+          locale_selections << SelectionHint.typename_node
         end
 
         if remote_selections
@@ -282,7 +282,7 @@ module GraphQL
           routes.each_value do |route|
             route.reduce(locale_selections) do |parent_selections, boundary|
               # E.1) Add the key of each boundary query into the prior location's selection set.
-              foreign_key = "_STITCH_#{boundary.key}"
+              foreign_key = SelectionHint.key(boundary.key)
               has_key = false
               has_typename = false
 
@@ -291,13 +291,13 @@ module GraphQL
                 case selection.alias
                 when foreign_key
                   has_key = true
-                when GraphQL::Stitching::TYPENAME_NODE.alias
+                when SelectionHint.typename_key
                   has_typename = true
                 end
               end
 
-              parent_selections << GraphQL::Language::Nodes::Field.new(alias: foreign_key, name: boundary.key) unless has_key
-              parent_selections << GraphQL::Stitching::TYPENAME_NODE unless has_typename
+              parent_selections << SelectionHint.key_node(boundary.key) unless has_key
+              parent_selections << SelectionHint.typename_node unless has_typename
 
               # E.2) Add a planner operation for each new entrypoint location.
               location = boundary.location

--- a/lib/graphql/stitching/selection_hint.rb
+++ b/lib/graphql/stitching/selection_hint.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Stitching
+    class SelectionHint
+      HINT_PREFIX = "_STITCH_"
+      TYPENAME_NODE = GraphQL::Language::Nodes::Field.new(alias: "#{HINT_PREFIX}typename", name: "__typename")
+
+      class << self
+        def key?(name)
+          return false unless name
+
+          name.start_with?(HINT_PREFIX)
+        end
+
+        def key(name)
+          "#{HINT_PREFIX}#{name}"
+        end
+
+        def key_node(field_name)
+          GraphQL::Language::Nodes::Field.new(alias: key(field_name), name: field_name)
+        end
+
+        def typename_key
+          TYPENAME_NODE.alias
+        end
+
+        def typename_node
+          TYPENAME_NODE
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -19,8 +19,8 @@ module GraphQL
       def resolve_object_scope(raw_object, parent_type, selections, typename = nil)
         return nil if raw_object.nil?
 
-        typename ||= raw_object["_STITCH_typename"]
-        raw_object.reject! { |k, _v| k.start_with?("_STITCH_") }
+        typename ||= raw_object[SelectionHint.typename_key]
+        raw_object.reject! { |key, _v| SelectionHint.key?(key) }
 
         selections.each do |node|
           case node

--- a/lib/graphql/stitching/skip_include.rb
+++ b/lib/graphql/stitching/skip_include.rb
@@ -35,7 +35,7 @@ module GraphQL
           end
 
           if filtered_selections.none?
-            filtered_selections << GraphQL::Stitching::TYPENAME_NODE
+            filtered_selections << SelectionHint.typename_node
           end
 
           if changed

--- a/test/graphql/stitching/selection_hint_test.rb
+++ b/test/graphql/stitching/selection_hint_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "GraphQL::Stitching::SelectionHint" do
+  def test_identifies_selection_hint_keys
+    assert GraphQL::Stitching::SelectionHint.key?("_STITCH_beep")
+    assert GraphQL::Stitching::SelectionHint.key?("_STITCH_typename")
+
+    assert_equal false, GraphQL::Stitching::SelectionHint.key?("beep")
+    assert_equal false, GraphQL::Stitching::SelectionHint.key?("__typename")
+    assert_equal false, GraphQL::Stitching::SelectionHint.key?(nil)
+  end
+
+  def test_builds_selection_hint_keys
+    assert_equal "_STITCH_beep", GraphQL::Stitching::SelectionHint.key("beep")
+  end
+
+  def test_builds_selection_hint_nodes
+    node = GraphQL::Stitching::SelectionHint.key_node("beep")
+    assert_equal "_STITCH_beep", node.alias
+    assert_equal "beep", node.name
+  end
+
+  def test_provides_typename_hint_key
+    assert_equal "_STITCH_typename", GraphQL::Stitching::SelectionHint.typename_key
+  end
+
+  def test_provides_typename_hint_node
+    node = GraphQL::Stitching::SelectionHint.typename_node
+    assert_equal "_STITCH_typename", node.alias
+    assert_equal "__typename", node.name
+  end
+end


### PR DESCRIPTION
Formalizes the wide-spread messiness of selection hints into a centralized concern.