### PR TITLE
Normalize typename selection hint format

### DIFF
--- a/lib/graphql/stitching/executor/boundary_source.rb
+++ b/lib/graphql/stitching/executor/boundary_source.rb
@@ -16,7 +16,7 @@ module GraphQL
 
           if op.if_type
             # operations planned around unused fragment conditions should not trigger requests
-            origin_set.select! { _1[SelectionHint.typename_key] == op.if_type }
+            origin_set.select! { _1[SelectionHint.typename_node.alias] == op.if_type }
           end
 
           memo[op] = origin_set if origin_set.any?
@@ -88,7 +88,7 @@ module GraphQL
       def build_key(key, origin_obj, federation: false)
         key_value = JSON.generate(origin_obj[SelectionHint.key(key)])
         if federation
-          "{ __typename: \"#{origin_obj[SelectionHint.typename_key]}\", #{key}: #{key_value} }"
+          "{ __typename: \"#{origin_obj[SelectionHint.typename_node.alias]}\", #{key}: #{key_value} }"
         else
           key_value
         end

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -291,7 +291,7 @@ module GraphQL
                 case selection.alias
                 when foreign_key
                   has_key = true
-                when SelectionHint.typename_key
+                when SelectionHint.typename_node.alias
                   has_typename = true
                 end
               end

--- a/lib/graphql/stitching/selection_hint.rb
+++ b/lib/graphql/stitching/selection_hint.rb
@@ -4,7 +4,6 @@ module GraphQL
   module Stitching
     class SelectionHint
       HINT_PREFIX = "_STITCH_"
-      TYPENAME_NODE = GraphQL::Language::Nodes::Field.new(alias: "#{HINT_PREFIX}typename", name: "__typename")
 
       class << self
         def key?(name)
@@ -21,12 +20,8 @@ module GraphQL
           GraphQL::Language::Nodes::Field.new(alias: key(field_name), name: field_name)
         end
 
-        def typename_key
-          TYPENAME_NODE.alias
-        end
-
         def typename_node
-          TYPENAME_NODE
+          @typename_node ||= key_node("__typename")
         end
       end
     end

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -19,7 +19,7 @@ module GraphQL
       def resolve_object_scope(raw_object, parent_type, selections, typename = nil)
         return nil if raw_object.nil?
 
-        typename ||= raw_object[SelectionHint.typename_key]
+        typename ||= raw_object[SelectionHint.typename_node.alias]
         raw_object.reject! { |key, _v| SelectionHint.key?(key) }
 
         selections.each do |node|

--- a/test/graphql/stitching/integration/multiple_generations_test.rb
+++ b/test/graphql/stitching/integration/multiple_generations_test.rb
@@ -91,14 +91,14 @@ describe 'GraphQL::Stitching, multiple generations' do
           {
             "upc" => "1",
             "_STITCH_upc" => "1",
-            "_STITCH_typename" => "Product",
+            "_STITCH___typename" => "Product",
             "name" => "iPhone",
             "price"=>699.99,
           },
           {
             "upc" => "2",
             "_STITCH_upc" => "2",
-            "_STITCH_typename" => "Product",
+            "_STITCH___typename" => "Product",
             "name" => "Apple Watch",
             "price"=>399.99,
           },

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -49,13 +49,13 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
           id
           ... on Product {
             _STITCH_id: id
-            _STITCH_typename: __typename
+            _STITCH___typename: __typename
           }
           ... on Bundle {
             name
             price
           }
-          _STITCH_typename: __typename
+          _STITCH___typename: __typename
         }
       }
     |
@@ -112,14 +112,14 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
           id
           ... on Product {
             _STITCH_id: id
-            _STITCH_typename: __typename
+            _STITCH___typename: __typename
           }
           ... on Bundle {
             name
             price
           }
-          _STITCH_typename: __typename
-          _STITCH_typename: __typename
+          _STITCH___typename: __typename
+          _STITCH___typename: __typename
         }
       }
     |
@@ -151,11 +151,11 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       {
         buyable(id: \"1\") {
           id
-          ... on Product { _STITCH_id: id _STITCH_typename: __typename }
+          ... on Product { _STITCH_id: id _STITCH___typename: __typename }
           ... on Bundle { name price }
-          _STITCH_typename: __typename
-          _STITCH_typename: __typename
-          _STITCH_typename: __typename
+          _STITCH___typename: __typename
+          _STITCH___typename: __typename
+          _STITCH___typename: __typename
         }
       }
     |
@@ -239,14 +239,14 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
           ... on Apple {
             a
             _STITCH_id: id
-            _STITCH_typename: __typename
+            _STITCH___typename: __typename
           }
           ... on Banana {
             a
             _STITCH_id: id
-            _STITCH_typename: __typename
+            _STITCH___typename: __typename
           }
-          _STITCH_typename: __typename
+          _STITCH___typename: __typename
         }
       }
     |

--- a/test/graphql/stitching/planner/plan_boundaries_test.rb
+++ b/test/graphql/stitching/planner/plan_boundaries_test.rb
@@ -83,7 +83,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     assert_equal "storefronts", first.location
     assert_equal "query", first.operation_type
     assert_equal [], first.path
-    assert_equal %|{ storefront(id: "1") { name products { _STITCH_upc: upc _STITCH_typename: __typename } } }|, first.selections
+    assert_equal %|{ storefront(id: "1") { name products { _STITCH_upc: upc _STITCH___typename: __typename } } }|, first.selections
     assert_equal 1, first.step
     assert_equal 0, first.after
     assert_nil first.boundary
@@ -92,7 +92,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     assert_equal "products", second.location
     assert_equal "query", second.operation_type
     assert_equal ["storefront", "products"], second.path
-    assert_equal "{ name manufacturer { products { name } _STITCH_id: id _STITCH_typename: __typename } }", second.selections
+    assert_equal "{ name manufacturer { products { name } _STITCH_id: id _STITCH___typename: __typename } }", second.selections
     assert_equal "product", second.boundary.field
     assert_equal "upc", second.boundary.key
     assert_equal first.step, second.after
@@ -129,7 +129,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     assert_equal "manufacturers", p1_first.location
     assert_equal "query", p1_first.operation_type
     assert_equal [], p1_first.path
-    assert_equal %|{ manufacturer(id: "1") { name _STITCH_id: id _STITCH_typename: __typename } }|, p1_first.selections
+    assert_equal %|{ manufacturer(id: "1") { name _STITCH_id: id _STITCH___typename: __typename } }|, p1_first.selections
     assert_equal 1, p1_first.step
     assert_equal 0, p1_first.after
     assert_nil p1_first.boundary
@@ -176,7 +176,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     first = plan.ops[0]
     assert_equal "a", first.location
     assert_equal [], first.path
-    assert_equal %|{ apple(id: "1") { id name _STITCH_id: id _STITCH_typename: __typename } }|, first.selections
+    assert_equal %|{ apple(id: "1") { id name _STITCH_id: id _STITCH___typename: __typename } }|, first.selections
     assert_equal 1, first.step
     assert_equal 0, first.after
     assert_nil first.boundary
@@ -213,7 +213,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     first = plan.ops[0]
     assert_equal "a", first.location
     assert_equal [], first.path
-    assert_equal %|{ apple(id: "1") { id name _STITCH_id: id _STITCH_typename: __typename } }|, first.selections
+    assert_equal %|{ apple(id: "1") { id name _STITCH_id: id _STITCH___typename: __typename } }|, first.selections
     assert_equal 1, first.step
     assert_equal 0, first.after
     assert_nil first.boundary
@@ -251,7 +251,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     first = plan.ops[0]
     assert_equal "a", first.location
     assert_equal [], first.path
-    assert_equal %|{ node(id: "1") { id ... on Apple { name _STITCH_id: id _STITCH_typename: __typename } _STITCH_typename: __typename } }|, first.selections
+    assert_equal %|{ node(id: "1") { id ... on Apple { name _STITCH_id: id _STITCH___typename: __typename } _STITCH___typename: __typename } }|, first.selections
     assert_equal 1, first.step
     assert_equal 0, first.after
     assert_nil first.boundary

--- a/test/graphql/stitching/planner/plan_delegations_test.rb
+++ b/test/graphql/stitching/planner/plan_delegations_test.rb
@@ -77,7 +77,7 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
 
     first = plan.ops[0]
     assert_equal "alpha", first.location
-    assert_equal %|{ alpha(id: \"1\") { a b _STITCH_id: id _STITCH_typename: __typename } }|, first.selections
+    assert_equal %|{ alpha(id: \"1\") { a b _STITCH_id: id _STITCH___typename: __typename } }|, first.selections
 
     second = plan.ops[1]
     assert_equal "charlie", second.location

--- a/test/graphql/stitching/planner/plan_fragments_test.rb
+++ b/test/graphql/stitching/planner/plan_fragments_test.rb
@@ -18,17 +18,17 @@ describe "GraphQL::Stitching::Planner, fragments" do
             id
             extensions {
               _STITCH_id: id
-              _STITCH_typename: __typename
+              _STITCH___typename: __typename
             }
           }
           ... on Banana {
             id
             extensions {
               _STITCH_id: id
-              _STITCH_typename: __typename
+              _STITCH___typename: __typename
             }
           }
-          _STITCH_typename: __typename
+          _STITCH___typename: __typename
         }
       }
     |
@@ -159,7 +159,7 @@ describe "GraphQL::Stitching::Planner, fragments" do
     second = plan.ops[1]
     assert_equal "alpha", second.location
     assert_equal ["namespace", "test"], second.path
-    assert_equal "{ a x y nest { a _STITCH_id: id _STITCH_typename: __typename } }", second.selections
+    assert_equal "{ a x y nest { a _STITCH_id: id _STITCH___typename: __typename } }", second.selections
 
     third = plan.ops[2]
     assert_equal "bravo", third.location

--- a/test/graphql/stitching/selection_hint_test.rb
+++ b/test/graphql/stitching/selection_hint_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 describe "GraphQL::Stitching::SelectionHint" do
   def test_identifies_selection_hint_keys
     assert GraphQL::Stitching::SelectionHint.key?("_STITCH_beep")
-    assert GraphQL::Stitching::SelectionHint.key?("_STITCH_typename")
+    assert GraphQL::Stitching::SelectionHint.key?("_STITCH___typename")
 
     assert_equal false, GraphQL::Stitching::SelectionHint.key?("beep")
     assert_equal false, GraphQL::Stitching::SelectionHint.key?("__typename")
@@ -22,13 +22,9 @@ describe "GraphQL::Stitching::SelectionHint" do
     assert_equal "beep", node.name
   end
 
-  def test_provides_typename_hint_key
-    assert_equal "_STITCH_typename", GraphQL::Stitching::SelectionHint.typename_key
-  end
-
   def test_provides_typename_hint_node
     node = GraphQL::Stitching::SelectionHint.typename_node
-    assert_equal "_STITCH_typename", node.alias
+    assert_equal "_STITCH___typename", node.alias
     assert_equal "__typename", node.name
   end
 end

--- a/test/graphql/stitching/shaper/grooming_test.rb
+++ b/test/graphql/stitching/shaper/grooming_test.rb
@@ -13,7 +13,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     raw = {
       "test" => {
         "_STITCH_req" => "yes",
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "__typename" => "Test",
         "req" => "yes",
         "opt" => nil,
@@ -39,7 +39,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     raw = {
       "test" => {
         "_STITCH_req" => "yes",
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "req" => "yes",
       }
     }
@@ -71,7 +71,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     raw = {
       "test" => {
         "_STITCH_req" => "yes",
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "req" => "yes",
       }
     }
@@ -99,7 +99,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     raw = {
       "test" => {
         "_STITCH_req" => "yes",
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "req" => "yes",
       }
     }

--- a/test/graphql/stitching/shaper/null_bubbling_test.rb
+++ b/test/graphql/stitching/shaper/null_bubbling_test.rb
@@ -255,7 +255,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
     )
     raw = {
       "test" => {
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "req" => nil,
         "opt" => nil
       }
@@ -280,7 +280,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
     )
     raw = {
       "test" => {
-        "_STITCH_typename" => "Test",
+        "_STITCH___typename" => "Test",
         "req" => nil,
         "opt" => nil
       }

--- a/test/graphql/stitching/skip_include_test.rb
+++ b/test/graphql/stitching/skip_include_test.rb
@@ -89,7 +89,7 @@ describe "GraphQL::Stitching::SkipInclude" do
 
     assert changed?
     assert_result "query {
-      a { _STITCH_typename: __typename }
+      a { _STITCH___typename: __typename }
     }"
   end
 


### PR DESCRIPTION
Normalizes the key format of `__typename` selection hints. Avoids conflicts with, say, a hint field called `typename`.