### PR TITLE
Passthrough operation-level directives

### DIFF
--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -412,15 +412,15 @@ module GraphQL
 
       # F) Wrap concrete selections targeting abstract boundaries in typed fragments.
       def expand_abstract_boundaries
-        @steps_by_entrypoint.each_value do |op|
-          next unless op.boundary
+        @steps_by_entrypoint.each_value do |step|
+          next unless step.boundary
 
-          boundary_type = @supergraph.memoized_schema_types[op.boundary.type_name]
+          boundary_type = @supergraph.memoized_schema_types[step.boundary.type_name]
           next unless boundary_type.kind.abstract?
-          next if boundary_type == op.parent_type
+          next if boundary_type == step.parent_type
 
           expanded_selections = nil
-          op.selections.reject! do |node|
+          step.selections.reject! do |node|
             if node.is_a?(GraphQL::Language::Nodes::Field)
               expanded_selections ||= []
               expanded_selections << node
@@ -429,8 +429,8 @@ module GraphQL
           end
 
           if expanded_selections
-            type_name = GraphQL::Language::Nodes::TypeName.new(name: op.parent_type.graphql_name)
-            op.selections << GraphQL::Language::Nodes::InlineFragment.new(type: type_name, selections: expanded_selections)
+            type_name = GraphQL::Language::Nodes::TypeName.new(name: step.parent_type.graphql_name)
+            step.selections << GraphQL::Language::Nodes::InlineFragment.new(type: type_name, selections: expanded_selections)
           end
         end
       end

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -48,6 +48,13 @@ module GraphQL
         end
       end
 
+      def operation_directives
+        @operation_directives ||= if operation.directives.any?
+          printer = GraphQL::Language::Printer.new
+          operation.directives.map { printer.print(_1) }.join(" ")
+        end
+      end
+
       def variable_definitions
         @variable_definitions ||= operation.variables.each_with_object({}) do |v, memo|
           memo[v.name] = v.type

--- a/lib/graphql/stitching/selection_hint.rb
+++ b/lib/graphql/stitching/selection_hint.rb
@@ -2,6 +2,8 @@
 
 module GraphQL
   module Stitching
+    # Builds hidden selection fields added by stitiching code,
+    # used to request operational data about resolved objects.
     class SelectionHint
       HINT_PREFIX = "_STITCH_"
 

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -3,6 +3,8 @@
 
 module GraphQL
   module Stitching
+    # Shapes the final results payload to the request selection and schema definition.
+    # This eliminates unrequested selection hints and applies null bubbling.
     class Shaper
       def initialize(supergraph:, request:)
         @supergraph = supergraph

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -60,7 +60,7 @@ module GraphQL
             result << type
             result.push(*expand_abstract_type(schema, type)) if type.kind.interface?
           end
-          result.uniq
+          result.tap(&:uniq!)
         end
       end
     end

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/test/graphql/stitching/executor/boundary_source_test.rb
+++ b/test/graphql/stitching/executor/boundary_source_test.rb
@@ -51,13 +51,13 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
   def test_builds_document_for_operation_batch
     query_document, variable_names = @source.build_document(@origin_sets_by_operation)
 
-    expected = <<~GRAPHQL
+    expected = %|
       query($lang:String!,$currency:Currency!){
         _0_result: storefronts(ids:["7","8"]) { name(lang:$lang) }
         _1_0_result: product(upc:"abc") { price(currency:$currency) }
         _1_1_result: product(upc:"xyz") { price(currency:$currency) }
       }
-    GRAPHQL
+    |
 
     assert_equal squish_string(expected), query_document
     assert_equal ["lang", "currency"], variable_names
@@ -66,13 +66,32 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
   def test_builds_document_with_operation_name
     query_document, variable_names = @source.build_document(@origin_sets_by_operation, "MyOperation")
 
-    expected = <<~GRAPHQL
+    expected = %|
       query MyOperation_2_3($lang:String!,$currency:Currency!){
         _0_result: storefronts(ids:["7","8"]) { name(lang:$lang) }
         _1_0_result: product(upc:"abc") { price(currency:$currency) }
         _1_1_result: product(upc:"xyz") { price(currency:$currency) }
       }
-    GRAPHQL
+    |
+
+    assert_equal squish_string(expected), query_document
+    assert_equal ["lang", "currency"], variable_names
+  end
+
+  def test_builds_document_with_operation_directives
+    query_document, variable_names = @source.build_document(
+      @origin_sets_by_operation,
+      "MyOperation",
+      %|@inContext(lang: "EN")|,
+    )
+
+    expected = %|
+      query MyOperation_2_3($lang:String!,$currency:Currency!) @inContext(lang: "EN") {
+        _0_result: storefronts(ids:["7","8"]) { name(lang:$lang) }
+        _1_0_result: product(upc:"abc") { price(currency:$currency) }
+        _1_1_result: product(upc:"xyz") { price(currency:$currency) }
+      }
+    |
 
     assert_equal squish_string(expected), query_document
     assert_equal ["lang", "currency"], variable_names

--- a/test/graphql/stitching/executor/executor_test.rb
+++ b/test/graphql/stitching/executor/executor_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "GraphQL::Stitching::Executor" do
+  def mock_execs(source, returns, operation_name: nil, variables: nil)
+    alpha = %|
+      #{STITCH_DEFINITION}
+      directive @inContext(lang: String!) on QUERY \| MUTATION
+      type Product { id: ID! name: String }
+      type Query { product(id: ID!): Product @stitch(key: "id") }
+    |
+    bravo = %|
+      type Product { id: ID! }
+      type Query { featured: [Product!]! }
+    |
+
+    results = []
+    supergraph = GraphQL::Stitching::Composer.new.perform({
+      alpha: {
+        schema: GraphQL::Schema.from_definition(alpha),
+        executable: -> (loc, src, vars, ctx) {
+          results << { location: loc, source: src }
+          { "data" => returns.shift }
+        },
+      },
+      bravo: {
+        schema: GraphQL::Schema.from_definition(bravo),
+        executable: -> (loc, src, vars, ctx) {
+          results << { location: loc, source: src }
+          { "data" => returns.shift }
+        },
+      },
+    })
+
+    request = GraphQL::Stitching::Request.new(
+      source,
+      operation_name: operation_name,
+      variables: variables,
+    ).prepare!
+
+    plan = GraphQL::Stitching::Planner.new(
+      supergraph: supergraph,
+      request: request,
+    ).perform
+
+    GraphQL::Stitching::Executor.new(
+      supergraph: supergraph,
+      request: request,
+      plan: plan,
+    ).perform
+
+    results
+  end
+
+  def test_with_batching
+    req = %|{ featured { name } }|
+
+    expected1 = %|
+      query{ featured { _STITCH_id: id _STITCH___typename: __typename } }
+    |
+    expected2 = %|
+      query{
+        _0_0_result: product(id:"1") { name }
+        _0_1_result: product(id:"2") { name }
+        _0_2_result: product(id:"3") { name }
+      }
+    |
+
+    execs = mock_execs(req, [
+      {
+        "featured" => [
+          { "_STITCH_id" => "1", "_STITCH___typename" => "Product" },
+          { "_STITCH_id" => "2", "_STITCH___typename" => "Product" },
+          { "_STITCH_id" => "3", "_STITCH___typename" => "Product" },
+        ]
+      },
+      {
+        "_0_0_result" => { "name" => "Potato" },
+        "_0_1_result" => { "name" => "Carrot" },
+        "_0_2_result" => { "name" => "Turnip" },
+      },
+    ])
+
+    assert_equal 2, execs.length
+
+    assert_equal "bravo", execs[0][:location]
+    assert_equal squish_string(expected1), execs[0][:source]
+
+    assert_equal "alpha", execs[1][:location]
+    assert_equal squish_string(expected2), execs[1][:source]
+  end
+
+  def test_with_operation_name_and_directives
+    req = %|query Test @inContext(lang: "EN") { featured { name } }|
+
+    expected1 = %|
+      query Test_1 @inContext(lang: "EN") { featured { _STITCH_id: id _STITCH___typename: __typename } }
+    |
+    expected2 = %|
+      query Test_2 @inContext(lang: "EN") { _0_0_result: product(id:"1") { name } }
+    |
+
+    execs = mock_execs(req, [
+      { "featured" => [{ "_STITCH_id" => "1", "_STITCH___typename" => "Product" }] },
+      { "_0_0_result" => { "name" => "Potato" } },
+    ], operation_name: "Test")
+
+    assert_equal 2, execs.length
+
+    assert_equal "bravo", execs[0][:location]
+    assert_equal squish_string(expected1), execs[0][:source]
+
+    assert_equal "alpha", execs[1][:location]
+    assert_equal squish_string(expected2), execs[1][:source]
+  end
+end

--- a/test/graphql/stitching/executor/root_source_test.rb
+++ b/test/graphql/stitching/executor/root_source_test.rb
@@ -22,11 +22,11 @@ describe "GraphQL::Stitching::Executor, RootSource" do
   def test_builds_document_for_an_operation
     source_document = @source.build_document(@op)
 
-    expected = <<~GRAPHQL
+    expected = %|
       query($id:ID!){
         storefront(id:$id) { products { _STITCH_id: id } }
       }
-    GRAPHQL
+    |
 
     assert_equal squish_string(expected), source_document
   end
@@ -34,11 +34,23 @@ describe "GraphQL::Stitching::Executor, RootSource" do
   def test_builds_document_with_operation_name
     source_document = @source.build_document(@op, "MyOperation")
 
-    expected = <<~GRAPHQL
+    expected = %|
       query MyOperation_1($id:ID!){
         storefront(id:$id) { products { _STITCH_id: id } }
       }
-    GRAPHQL
+    |
+
+    assert_equal squish_string(expected), source_document
+  end
+
+  def test_builds_document_with_operation_directives
+    source_document = @source.build_document(@op, "MyOperation", %|@inContext(lang: "EN")|)
+
+    expected = %|
+      query MyOperation_1($id:ID!) @inContext(lang: "EN") {
+        storefront(id:$id) { products { _STITCH_id: id } }
+      }
+    |
 
     assert_equal squish_string(expected), source_document
   end

--- a/test/graphql/stitching/integration/conditionals_test.rb
+++ b/test/graphql/stitching/integration/conditionals_test.rb
@@ -11,7 +11,7 @@ describe 'GraphQL::Stitching, type conditions' do
       "base" => Schemas::Conditionals::Abstracts,
     })
 
-    @query = <<~GRAPHQL
+    @query = %|
       query($ids: [ID!]!) {
         fruits(ids: $ids) {
           ...on Apple { extensions { color } }
@@ -19,7 +19,7 @@ describe 'GraphQL::Stitching, type conditions' do
           __typename
         }
       }
-    GRAPHQL
+    |
   end
 
   def test_performs_specific_queries_planned_for_the_returned_type
@@ -66,7 +66,7 @@ describe 'GraphQL::Stitching, type conditions' do
   end
 
   def test_performs_specific_queries_planned_for_the_returned_type_via_fragment
-    @query = <<~GRAPHQL
+    @query = %|
       query($ids: [ID!]!) {
         fruits(ids: $ids) {
           ...on HasExtension {
@@ -77,7 +77,7 @@ describe 'GraphQL::Stitching, type conditions' do
           }
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, @query, {
       "ids" => ["1"]
@@ -97,7 +97,7 @@ describe 'GraphQL::Stitching, type conditions' do
   end
 
   def test_performs_all_queries_for_all_returned_types_via_fragment
-    @query = <<~GRAPHQL
+    @query = %|
       query($ids: [ID!]!) {
         fruits(ids: $ids) {
           ...on HasExtension {
@@ -111,7 +111,7 @@ describe 'GraphQL::Stitching, type conditions' do
         ...on AppleExtension { color }
         ...on BananaExtension { shape }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, @query, {
       "ids" => ["1", "2"]

--- a/test/graphql/stitching/integration/mutations_test.rb
+++ b/test/graphql/stitching/integration/mutations_test.rb
@@ -14,7 +14,7 @@ describe 'GraphQL::Stitching, mutations' do
   end
 
   def test_mutates_serially_and_stitches_results
-    mutations = <<~GRAPHQL
+    mutations = %|
       mutation AddRecords {
         first:  addViaA { id via a b }
         second: addViaB { id via a b }
@@ -22,7 +22,7 @@ describe 'GraphQL::Stitching, mutations' do
         fourth: addViaA { id via a b }
         fifth:  addViaA { id via a b }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, mutations)
 

--- a/test/graphql/stitching/integration/shareables_test.rb
+++ b/test/graphql/stitching/integration/shareables_test.rb
@@ -12,7 +12,7 @@ describe 'GraphQL::Stitching, shareables' do
   end
 
   def test_mutates_serially_and_stitches_results
-    query = <<~GRAPHQL
+    query = %|
       query {
         gadgetA(id: "1") {
           id
@@ -29,7 +29,7 @@ describe 'GraphQL::Stitching, shareables' do
           uniqueToB
         }
       }
-    GRAPHQL
+    |
 
     result = plan_and_execute(@supergraph, query)
 

--- a/test/graphql/stitching/integration/unions_test.rb
+++ b/test/graphql/stitching/integration/unions_test.rb
@@ -13,15 +13,15 @@ describe 'GraphQL::Stitching, unions' do
   end
 
   def test_plan_abstract_merged_via_concrete_boundaries
-    query = <<~GRAPHQL
+    query = %|
       {
-        fruitsA(ids: [\"1\", \"3\"]) {
+        fruitsA(ids: ["1", "3"]) {
           ...on Apple { a b c }
           ...on Banana { a b }
           ...on Coconut { b c }
         }
       }
-    GRAPHQL
+    |
 
     expected = {
       "fruitsA" => [
@@ -35,15 +35,15 @@ describe 'GraphQL::Stitching, unions' do
   end
 
   def test_plan_abstract_merged_types_via_abstract_boundary
-    query = <<~GRAPHQL
+    query = %|
       {
-        fruitsC(ids: [\"1\", \"4\"]) {
+        fruitsC(ids: ["1", "4"]) {
           ...on Apple { a b c }
           ...on Banana { a b }
           ...on Coconut { b c }
         }
       }
-    GRAPHQL
+    |
 
     expected = {
       "fruitsC" => [

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -59,6 +59,19 @@ describe "GraphQL::Stitching::Request" do
     end
   end
 
+  def test_access_operation_directives
+    query = %|
+      query First @inContext(lang: "EN") { widget { id } }
+      mutation Second @alpha(a: 1) @bravo(b: true) { makeSprocket(id: "1") { id } }
+    |
+
+    request1 = GraphQL::Stitching::Request.new(query, operation_name: "First")
+    request2 = GraphQL::Stitching::Request.new(query, operation_name: "Second")
+
+    assert_equal %|@inContext(lang: "EN")|, request1.operation_directives
+    assert_equal %|@alpha(a: 1) @bravo(b: true)|, request2.operation_directives
+  end
+
   def test_accesses_document_variable_definitions
     query = "
       query($ids: [ID!]!, $ns: String!, $lang: String) {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ require 'graphql/stitching'
 
 ComposerError = GraphQL::Stitching::Composer::ComposerError
 ValidationError = GraphQL::Stitching::Composer::ValidationError
+STITCH_DEFINITION = "directive @stitch(key: String!) repeatable on FIELD_DEFINITION\n"
 
 def squish_string(str)
   str.gsub(/\s+/, " ").strip
@@ -37,8 +38,7 @@ end
 def compose_definitions(locations, options={})
   locations = locations.each_with_object({}) do |(location, schema_or_sdl), memo|
     schema = if schema_or_sdl.is_a?(String)
-      boundary = "directive @stitch(key: String!) repeatable on FIELD_DEFINITION\n"
-      schema_or_sdl = boundary + schema_or_sdl if schema_or_sdl.include?("@stitch")
+      schema_or_sdl = STITCH_DEFINITION + schema_or_sdl if schema_or_sdl.include?("@stitch")
       GraphQL::Schema.from_definition(schema_or_sdl)
     else
       schema_or_sdl


### PR DESCRIPTION
Passes through operation-level directives into all subgraph executions. Ex:

```graphql
query @inContext(lang: "FR") {
  getFromA # << query @inContext(lang: "FR") { getFromA }
  getFromB # << query @inContext(lang: "FR") { getFromB }
}
```