### PR TITLE
Fix composer skipping arguments

### DIFF
--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -362,8 +362,8 @@ module GraphQL
             next
           end
 
-          # Getting double args sometimes... why?
-          return if owner.arguments.any? { _1.first == argument_name }
+          # Getting double args sometimes on auto-generated connection types... why?
+          next if owner.arguments.any? { _1.first == argument_name }
 
           type = merge_value_types(type_name, value_types, argument_name: argument_name, field_name: field_name)
           schema_argument = owner.argument(


### PR DESCRIPTION
Resolves https://github.com/gmac/graphql-stitching-ruby/issues/82.

There's a hack that exits argument merging when the argument already exists, which seems to happen for auto-generated connection arguments (needs more investigation). However, this hack returned early and potentially skipped other arguments. This keeps the hack in place, but simply continues through to subsequent arguments.

Thanks @mikeharty for the report.