### PR TITLE
Improve `NOT_CONFIGURED` check

### DIFF
--- a/docs/composer.md
+++ b/docs/composer.md
@@ -12,6 +12,7 @@ composer = GraphQL::Stitching::Composer.new(
   mutation_name: "Mutation",
   description_merger: ->(values_by_location, info) { values_by_location.values.join("\n") },
   deprecation_merger: ->(values_by_location, info) { values_by_location.values.first },
+  default_value_merger: ->(values_by_location, info) { values_by_location.values.first },
   directive_kwarg_merger: ->(values_by_location, info) { values_by_location.values.last },
   root_field_location_selector: ->(locations, info) { locations.last },
 )
@@ -26,6 +27,8 @@ Constructor arguments:
 - **`description_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging element description strings from across locations.
 
 - **`deprecation_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging element deprecation strings from across locations.
+
+- **`default_value_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging argument default values from across locations.
 
 - **`directive_kwarg_merger:`** _optional_, a [value merger function](#value-merger-functions) for merging directive keyword arguments from across locations.
 

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -5,9 +5,13 @@ module GraphQL
     class Composer
       class ComposerError < StitchingError; end
       class ValidationError < ComposerError; end
+      class ReferenceType < GraphQL::Schema::Object
+        field(:f, String) do
+          argument(:a, String)
+        end
+      end
 
-      attr_reader :query_name, :mutation_name, :candidate_types_by_name_and_location, :schema_directives
-
+      NO_DEFAULT_VALUE = ReferenceType.get_field("f").get_argument("a").default_value
       BASIC_VALUE_MERGER = ->(values_by_location, _info) { values_by_location.values.find { !_1.nil? } }
       BASIC_ROOT_FIELD_LOCATION_SELECTOR = ->(locations, _info) { locations.last }
 
@@ -15,6 +19,8 @@ module GraphQL
         "ValidateInterfaces",
         "ValidateBoundaries",
       ].freeze
+
+      attr_reader :query_name, :mutation_name, :candidate_types_by_name_and_location, :schema_directives
 
       def initialize(
         query_name: "Query",

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -37,6 +37,10 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
     @supergraph = compose_definitions({ "a" => a, "b" => b })
   end
 
+  def test_get_not_configured
+    puts GraphQL::Stitching::Composer::NO_DEFAULT_VALUE
+  end
+
   def test_expands_interface_selections_for_target_location
     plan = GraphQL::Stitching::Planner.new(
       supergraph: @supergraph,

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -37,10 +37,6 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
     @supergraph = compose_definitions({ "a" => a, "b" => b })
   end
 
-  def test_get_not_configured
-    puts GraphQL::Stitching::Composer::NO_DEFAULT_VALUE
-  end
-
   def test_expands_interface_selections_for_target_location
     plan = GraphQL::Stitching::Planner.new(
       supergraph: @supergraph,


### PR DESCRIPTION
Merging default values must be aware of the `NOT_CONFIGURED` symbol, which is private in GraphQL Ruby and has changed value over time. To improve the reliability of this check, this simply builds a GraphQL argument and collects its `default_value` as the basis for these checks.