### PR TITLE
Compose Enum values by name

### DIFF
--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.0.3"
+    VERSION = "1.0.4"
   end
 end

--- a/test/graphql/stitching/composer/merge_enum_test.rb
+++ b/test/graphql/stitching/composer/merge_enum_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 describe 'GraphQL::Stitching::Composer, merging enums' do
 
   def test_merges_enum_and_value_descriptions
-    a = %{"""a""" enum Status { """a""" YES } type Query { status:Status }}
-    b = %{"""b""" enum Status { """b""" YES } type Query { status:Status }}
+    a = %|"""a""" enum Status { """a""" YES } type Query { status:Status }|
+    b = %|"""b""" enum Status { """b""" YES } type Query { status:Status }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
       description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
@@ -17,17 +17,17 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
   end
 
   def test_merges_enum_and_value_directives
-    a = <<~GRAPHQL
-      directive @fizzbuzz(arg: String!) on ENUM | ENUM_VALUE
+    a = %|
+      directive @fizzbuzz(arg: String!) on ENUM \| ENUM_VALUE
       enum Status @fizzbuzz(arg: "a") { YES @fizzbuzz(arg: "a") }
       type Query { status:Status }
-    GRAPHQL
+    |
 
-    b = <<~GRAPHQL
-      directive @fizzbuzz(arg: String!) on ENUM | ENUM_VALUE
+    b = %|
+      directive @fizzbuzz(arg: String!) on ENUM \| ENUM_VALUE
       enum Status @fizzbuzz(arg: "b") { YES @fizzbuzz(arg: "b") }
       type Query { status:Status }
-    GRAPHQL
+    |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
       directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
@@ -38,8 +38,8 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
   end
 
   def test_merges_enum_values_using_union_when_readonly
-    a = %{enum Status { YES NO } type Query { status:Status }}
-    b = %{enum Status { YES NO MAYBE } type Query { status:Status }}
+    a = %|enum Status { YES NO } type Query { status:Status }|
+    b = %|enum Status { YES NO MAYBE } type Query { status:Status }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
@@ -47,8 +47,8 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
   end
 
   def test_merges_enum_values_using_intersection_when_input_via_field_arg
-    a = %{enum Status { YES NO } type Query { status1:Status }}
-    b = %{enum Status { YES NO MAYBE } type Query { status2(s:Status):Status }}
+    a = %|enum Status { YES NO } type Query { status1:Status }|
+    b = %|enum Status { YES NO MAYBE } type Query { status2(s:Status):Status }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
@@ -56,11 +56,43 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
   end
 
   def test_merges_enum_values_using_intersection_when_input_via_object
-    a = %{enum Status { YES NO } input MyStatus { status:Status } type Query { status1(s:MyStatus):Status }}
-    b = %{enum Status { YES NO MAYBE } type Query { status:Status }}
+    a = %|enum Status { YES NO } input MyStatus { status:Status } type Query { status1(s:MyStatus):Status }|
+    b = %|enum Status { YES NO MAYBE } type Query { status:Status }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
     assert_equal ["NO", "YES"], supergraph.schema.types["Status"].values.keys.sort
+  end
+
+  class SchemaAlpha < GraphQL::Schema
+    class Toggle < GraphQL::Schema::Enum
+      value("ON", value: "1")
+      value("OFF", value: "0")
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :a, Toggle
+    end
+    query Query
+  end
+
+  class SchemaBravo < GraphQL::Schema
+    class Toggle < GraphQL::Schema::Enum
+      value("ON", value: true)
+      value("OFF", value: false)
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :b, Toggle
+    end
+    query Query
+  end
+
+  def test_merges_class_based_enums_with_value_mappings
+    supergraph = compose_definitions({ "a" => SchemaAlpha, "b" => SchemaBravo })
+
+    assert_equal ["OFF", "ON"], supergraph.schema.types["Toggle"].values.keys.sort
+    assert_equal ["OFF", "ON"], supergraph.schema.types["Toggle"].values.values.map(&:graphql_name).sort
+    assert_equal ["OFF", "ON"], supergraph.schema.types["Toggle"].values.values.map(&:value).sort
   end
 end


### PR DESCRIPTION
Resolves https://github.com/gmac/graphql-stitching-ruby/issues/80. Thanks to @mikeharty for the report.

Switches enum composition to use each value's GraphQL name rather than its mapped value. While name and mapped value are always the same in parsed schemas, this is not necessarily true in class-based schemas.

Also, enum value names are set as their mapped values in the composed schema – no need to run mapped values through a merger because the composed schema never executes.