### PR TITLE
fix: Apply default values to variables in Request.prepare only if they are nil

### DIFF
--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -69,7 +69,7 @@ module GraphQL
 
       def prepare!
         operation.variables.each do |v|
-          @variables[v.name] ||= v.default_value
+          @variables[v.name] = v.default_value if @variables[v.name].nil?
         end
 
         if @may_contain_runtime_directives

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -137,7 +137,8 @@ describe "GraphQL::Stitching::Request" do
       }
     GRAPHQL
 
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: { "a" => true, "b" => false, "c" => false })
+    variables = { "a" => true, "b" => false, "c" => false }
+    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: variables)
     request.prepare!
 
     expected = { "a" => true, "b" => false, "c" => false }

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -130,6 +130,20 @@ describe "GraphQL::Stitching::Request" do
     assert_equal expected, request.variables
   end
 
+  def test_prepare_variables_preserves_boolean_values
+    query = <<~GRAPHQL
+      query($a: Boolean, $b: Boolean, $c: Boolean = true) {
+        base(a: $a, b: $b, c: $c) { id }
+      }
+    GRAPHQL
+
+    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: { "a" => true, "b" => false, "c" => false })
+    request.prepare!
+
+    expected = { "a" => true, "b" => false, "c" => false }
+    assert_equal expected, request.variables
+  end
+
   def test_applies_skip_and_include_directives_via_boolean_literals
     query = <<~GRAPHQL
       query {


### PR DESCRIPTION
See: #91 