### PR TITLE
Fix extraction of single errors

### DIFF
--- a/lib/graphql/stitching/executor/boundary_source.rb
+++ b/lib/graphql/stitching/executor/boundary_source.rb
@@ -160,7 +160,8 @@ module GraphQL
             errors_result.concat(pathed_errors_by_object_id.values)
           end
         end
-        errors_result.flatten!
+
+        errors_result.tap(&:flatten!)
       end
 
       private


### PR DESCRIPTION
Fixes https://github.com/gmac/graphql-stitching-ruby/issues/93, involving a bad call to `flatten!` that returned nil for flat arrays. Thanks to @shyouhei for the report.