### PR TITLE
Refactor component signatures

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -60,11 +60,11 @@ The client provides cache hooks to enable caching query plans across requests. W
 
 ```ruby
 client.on_cache_read do |request|
-  $redis.get(request.digest) # << 3P code
+  $cache.get(request.digest) # << 3P code
 end
 
 client.on_cache_write do |request, payload|
-  $redis.set(request.digest, payload) # << 3P code
+  $cache.set(request.digest, payload) # << 3P code
 end
 ```
 

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -20,8 +20,11 @@ request = GraphQL::Stitching::Request.new(
   context: { ... },
 )
 
-plan = request.plan
+# Via Request:
 result = request.execute
+
+# Via Executor:
+result = GraphQL::Stitching::Executor.new(request).perform
 ```
 
 ### Raw results
@@ -29,8 +32,9 @@ result = request.execute
 By default, execution results are always returned with document shaping (stitching additions removed, missing fields added, null bubbling applied). You may access the raw execution result by calling the `perform` method with a `raw: true` argument:
 
 ```ruby
-# get the raw result without shaping
+# get the raw result without shaping using either form:
 raw_result = request.execute(raw: true)
+raw_result = GraphQL::Stitching::Executor.new(request).perform(raw: true)
 ```
 
 The raw result will contain many irregularities from the stitching process, however may be insightful when debugging inconsistencies in results:

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -13,22 +13,15 @@ query = <<~GRAPHQL
 GRAPHQL
 
 request = GraphQL::Stitching::Request.new(
+  supergraph,
   query,
   variables: { "id" => "123" },
   operation_name: "MyQuery",
   context: { ... },
 )
 
-plan = GraphQL::Stitching::Planner.new(
-  supergraph: supergraph,
-  request: request,
-).perform
-
-result = GraphQL::Stitching::Executor.new(
-  supergraph: supergraph,
-  request: request,
-  plan: plan,
-).perform
+plan = request.plan
+result = request.execute
 ```
 
 ### Raw results
@@ -37,11 +30,7 @@ By default, execution results are always returned with document shaping (stitchi
 
 ```ruby
 # get the raw result without shaping
-raw_result = GraphQL::Stitching::Executor.new(
-  supergraph: supergraph,
-  request: request,
-  plan: plan,
-).perform(raw: true)
+raw_result = request.execute(raw: true)
 ```
 
 The raw result will contain many irregularities from the stitching process, however may be insightful when debugging inconsistencies in results:

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -31,15 +31,14 @@ plan = GraphQL::Stitching::Planner.new(request).perform
 Plans are designed to be cacheable. This is very useful for redundant GraphQL documents (commonly sent by frontend clients) where there's no sense in planning every request individually. It's far more efficient to generate a plan once and cache it, then simply retreive the plan and execute it for future requests.
 
 ```ruby
-cached_plan = $redis.get(request.digest)
+cached_plan = $cache.get(request.digest)
 
-plan = if cached_plan
-  GraphQL::Stitching::Plan.from_json(JSON.parse(cached_plan))
+if cached_plan
+  plan = GraphQL::Stitching::Plan.from_json(JSON.parse(cached_plan))
+  request.plan(plan)
 else
   plan = request.plan
-
-  $redis.set(request.digest, JSON.generate(plan.as_json))
-  plan
+  $cache.set(request.digest, JSON.generate(plan.as_json))
 end
 
 # execute the plan...

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -13,15 +13,13 @@ document = <<~GRAPHQL
 GRAPHQL
 
 request = GraphQL::Stitching::Request.new(
+  supergraph,
   document,
   variables: { "id" => "1" },
   operation_name: "MyQuery",
 ).prepare!
 
-plan = GraphQL::Stitching::Planner.new(
-  supergraph: supergraph,
-  request: request,
-).perform
+plan = request.plan
 ```
 
 ### Caching
@@ -34,10 +32,7 @@ cached_plan = $redis.get(request.digest)
 plan = if cached_plan
   GraphQL::Stitching::Plan.from_json(JSON.parse(cached_plan))
 else
-  plan = GraphQL::Stitching::Planner.new(
-    supergraph: supergraph,
-    request: request,
-  ).perform
+  plan = request.plan
 
   $redis.set(request.digest, JSON.generate(plan.as_json))
   plan

--- a/docs/planner.md
+++ b/docs/planner.md
@@ -19,7 +19,11 @@ request = GraphQL::Stitching::Request.new(
   operation_name: "MyQuery",
 ).prepare!
 
+# Via Request:
 plan = request.plan
+
+# Via Planner:
+plan = GraphQL::Stitching::Planner.new(request).perform
 ```
 
 ### Caching

--- a/docs/request.md
+++ b/docs/request.md
@@ -5,6 +5,7 @@ A `Request` contains a parsed GraphQL document and variables, and handles the lo
 ```ruby
 source = "query FetchMovie($id: ID!) { movie(id:$id) { id genre } }"
 request = GraphQL::Stitching::Request.new(
+  supergraph,
   source,
   variables: { "id" => "1" },
   operation_name: "FetchMovie",
@@ -42,6 +43,7 @@ document = <<~GRAPHQL
 GRAPHQL
 
 request = GraphQL::Stitching::Request.new(
+  supergraph,
   document,
   variables: { "id" => "1" },
   operation_name: "FetchMovie",

--- a/docs/supergraph.md
+++ b/docs/supergraph.md
@@ -10,7 +10,7 @@ A Supergraph is designed to be composed, cached, and restored. Calling `to_defin
 supergraph_sdl = supergraph.to_definition
 
 # stash this composed schema in a cache...
-$redis.set("cached_supergraph_sdl", supergraph_sdl)
+$cache.set("cached_supergraph_sdl", supergraph_sdl)
 
 # or, write the composed schema as a file into your repo...
 File.write("supergraph/schema.graphql", supergraph_sdl)
@@ -19,7 +19,7 @@ File.write("supergraph/schema.graphql", supergraph_sdl)
 To restore a Supergraph, call `from_definition` providing the cached SDL string and a hash of executables keyed by their location names:
 
 ```ruby
-supergraph_sdl = $redis.get("cached_supergraph_sdl")
+supergraph_sdl = $cache.get("cached_supergraph_sdl")
 
 supergraph = GraphQL::Stitching::Supergraph.from_definition(
   supergraph_sdl,

--- a/lib/graphql/stitching/client.rb
+++ b/lib/graphql/stitching/client.rb
@@ -41,7 +41,11 @@ module GraphQL
         end
 
         request.prepare!
-        request.plan = fetch_plan(request) { request.plan }
+        request.plan do
+          fetch_plan(request) do
+            GraphQL::Stitching::Planner.new(request).perform
+          end
+        end
         request.execute
       rescue GraphQL::ParseError, GraphQL::ExecutionError => e
         error_result([e])

--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -8,10 +8,10 @@ module GraphQL
       attr_reader :supergraph, :request, :plan, :data, :errors
       attr_accessor :query_count
 
-      def initialize(supergraph:, request:, plan:, nonblocking: false)
-        @supergraph = supergraph
+      def initialize(request, nonblocking: false)
         @request = request
-        @plan = plan
+        @supergraph = request.supergraph
+        @plan = request.plan
         @data = {}
         @errors = []
         @query_count = 0
@@ -24,10 +24,7 @@ module GraphQL
         result = {}
 
         if @data && @data.length > 0
-          result["data"] = raw ? @data : GraphQL::Stitching::Shaper.new(
-            supergraph: @supergraph,
-            request: @request,
-          ).perform!(@data)
+          result["data"] = raw ? @data : GraphQL::Stitching::Shaper.new(@request).perform!(@data)
         end
 
         if @errors.length > 0

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -9,9 +9,9 @@ module GraphQL
       MUTATION_OP = "mutation"
       ROOT_INDEX = 0
 
-      def initialize(supergraph:, request:)
-        @supergraph = supergraph
+      def initialize(request)
         @request = request
+        @supergraph = request.supergraph
         @planning_index = ROOT_INDEX
         @steps_by_entrypoint = {}
       end

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -103,10 +103,11 @@ module GraphQL
       end
 
       def plan
-        @plan ||= GraphQL::Stitching::Planner.new(self).perform
+        @plan ||= begin
+          plan = yield if block_given?
+          plan || GraphQL::Stitching::Planner.new(self).perform
+        end
       end
-
-      attr_writer :plan
 
       def execute(raw: false)
         GraphQL::Stitching::Executor.new(self).perform(raw:)

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -102,10 +102,12 @@ module GraphQL
         self
       end
 
-      def plan
-        @plan ||= begin
-          plan = yield if block_given?
-          plan || GraphQL::Stitching::Planner.new(self).perform
+      def plan(new_plan = nil)
+        if new_plan
+          raise StitchingError, "Plan must be a `GraphQL::Stitching::Plan` instance" unless new_plan.is_a?(Plan)
+          @plan = new_plan
+        else
+          @plan ||= GraphQL::Stitching::Planner.new(self).perform
         end
       end
 

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -104,7 +104,7 @@ module GraphQL
 
       def plan(new_plan = nil)
         if new_plan
-          raise StitchingError, "Plan must be a `GraphQL::Stitching::Plan` instance" unless new_plan.is_a?(Plan)
+          raise StitchingError, "Plan must be a `GraphQL::Stitching::Plan`." unless new_plan.is_a?(Plan)
           @plan = new_plan
         else
           @plan ||= GraphQL::Stitching::Planner.new(self).perform

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -112,7 +112,7 @@ module GraphQL
       end
 
       def execute(raw: false)
-        GraphQL::Stitching::Executor.new(self).perform(raw:)
+        GraphQL::Stitching::Executor.new(self).perform(raw: raw)
       end
     end
   end

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -6,9 +6,9 @@ module GraphQL
     # Shapes the final results payload to the request selection and schema definition.
     # This eliminates unrequested export selections and applies null bubbling.
     class Shaper
-      def initialize(supergraph:, request:)
-        @supergraph = supergraph
+      def initialize(request)
         @request = request
+        @supergraph = request.supergraph
         @root_type = nil
       end
 

--- a/test/graphql/stitching/executor/boundary_source_test.rb
+++ b/test/graphql/stitching/executor/boundary_source_test.rb
@@ -158,7 +158,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
     }
 
     mock = GraphQL::Stitching::Request.new({}, "{}")
-    mock.plan = GraphQL::Stitching::Plan.new(ops: [])
+    mock.plan { GraphQL::Stitching::Plan.new(ops: []) }
 
     mock = GraphQL::Stitching::Executor.new(mock)
     mock.instance_variable_set(:@data, data)

--- a/test/graphql/stitching/executor/boundary_source_test.rb
+++ b/test/graphql/stitching/executor/boundary_source_test.rb
@@ -157,9 +157,10 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
       ]
     }
 
-    plan = GraphQL::Stitching::Plan.new(ops: [])
-    mock = GraphQL::Stitching::Request.new("{}")
-    mock = GraphQL::Stitching::Executor.new(supergraph: {}, request: mock, plan: plan)
+    mock = GraphQL::Stitching::Request.new({}, "{}")
+    mock.plan = GraphQL::Stitching::Plan.new(ops: [])
+
+    mock = GraphQL::Stitching::Executor.new(mock)
     mock.instance_variable_set(:@data, data)
 
     source = GraphQL::Stitching::Executor::BoundarySource.new(mock, "products")

--- a/test/graphql/stitching/executor/boundary_source_test.rb
+++ b/test/graphql/stitching/executor/boundary_source_test.rb
@@ -158,7 +158,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
     }
 
     mock = GraphQL::Stitching::Request.new({}, "{}")
-    mock.plan { GraphQL::Stitching::Plan.new(ops: []) }
+    mock.plan(GraphQL::Stitching::Plan.new(ops: []))
 
     mock = GraphQL::Stitching::Executor.new(mock)
     mock.instance_variable_set(:@data, data)

--- a/test/graphql/stitching/executor/executor_test.rb
+++ b/test/graphql/stitching/executor/executor_test.rb
@@ -33,22 +33,12 @@ describe "GraphQL::Stitching::Executor" do
       },
     })
 
-    request = GraphQL::Stitching::Request.new(
+    GraphQL::Stitching::Request.new(
+      supergraph,
       source,
       operation_name: operation_name,
       variables: variables,
-    ).prepare!
-
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: request,
-    ).perform
-
-    GraphQL::Stitching::Executor.new(
-      supergraph: supergraph,
-      request: request,
-      plan: plan,
-    ).perform
+    ).prepare!.execute
 
     results
   end

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -38,10 +38,10 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
   end
 
   def test_expands_interface_selections_for_target_location
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new("{ buyable(id:\"1\") { id name price } }"),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      "{ buyable(id:\"1\") { id name price } }",
+    ).plan
 
     expected_root_selection = %|
       {
@@ -129,10 +129,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
     |
 
     [document1, document2, document3].each do |document|
-      plan = GraphQL::Stitching::Planner.new(
-        supergraph: @supergraph,
-        request: GraphQL::Stitching::Request.new(document),
-      ).perform
+      plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
       assert_equal 2, plan.ops.length
       assert_equal squish_string(expected_root_selection), plan.ops.first.selections
@@ -164,20 +161,17 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     assert_equal 2, plan.ops.length
     assert_equal squish_string(expected_root_selection), plan.ops.first.selections
   end
 
   def test_retains_interface_selections_appropraite_to_the_location
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(%|{ products(ids:["1"]) { id name price } }|),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      %|{ products(ids:["1"]) { id name price } }|,
+    ).plan
 
     assert_equal 1, plan.ops.length
     assert_keys plan.ops[0].as_json, {
@@ -232,10 +226,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
 
     @supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c })
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     expected_root_selection = %|
       {

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -40,7 +40,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
   def test_expands_interface_selections_for_target_location
     plan = GraphQL::Stitching::Request.new(
       @supergraph,
-      "{ buyable(id:\"1\") { id name price } }",
+      %|{ buyable(id:"1") { id name price } }|,
     ).plan
 
     expected_root_selection = %|

--- a/test/graphql/stitching/planner/plan_boundaries_test.rb
+++ b/test/graphql/stitching/planner/plan_boundaries_test.rb
@@ -72,10 +72,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: build_sample_graph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(build_sample_graph, document).plan
 
     assert_equal 3, plan.ops.length
 
@@ -118,15 +115,8 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     document1 = %|{         manufacturer(id: "1") { name products { name } } }|
     document2 = %|{ productsManufacturer(id: "1") { name products { name } } }|
 
-    plan1 = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: GraphQL::Stitching::Request.new(document1),
-    ).perform
-
-    plan2 = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: GraphQL::Stitching::Request.new(document2),
-    ).perform
+    plan1 = GraphQL::Stitching::Request.new(supergraph, document1).plan
+    plan2 = GraphQL::Stitching::Request.new(supergraph, document2).plan
 
     assert_equal 2, plan1.ops.length
     assert_equal 1, plan2.ops.length
@@ -177,10 +167,10 @@ describe "GraphQL::Stitching::Planner, boundaries" do
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: GraphQL::Stitching::Request.new(%|{ apple(id:"1") { id name weight } }|),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      supergraph,
+      %|{ apple(id:"1") { id name weight } }|,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -221,10 +211,10 @@ describe "GraphQL::Stitching::Planner, boundaries" do
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: GraphQL::Stitching::Request.new("{ apple(id:\"1\") { id name weight } }"),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      supergraph,
+      %|{ apple(id:"1") { id name weight } }|,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -266,10 +256,10 @@ describe "GraphQL::Stitching::Planner, boundaries" do
 
     supergraph = compose_definitions({ "a" => a, "b" => b })
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: supergraph,
-      request: GraphQL::Stitching::Request.new(%|{ node(id:"1") { id ...on Apple { name weight } } }|),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      supergraph,
+      %|{ node(id:"1") { id ...on Apple { name weight } } }|,
+    ).plan
 
     assert_equal 2, plan.ops.length
 

--- a/test/graphql/stitching/planner/plan_delegations_test.rb
+++ b/test/graphql/stitching/planner/plan_delegations_test.rb
@@ -48,19 +48,19 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
   })
 
   def test_delegates_common_fields_to_current_routing_location
-    plan1 = GraphQL::Stitching::Planner.new(
-      supergraph: SUPERGRAPH,
-      request: GraphQL::Stitching::Request.new('query { alpha(id: "1") { a b } }'),
-    ).perform
+    plan1 = GraphQL::Stitching::Request.new(
+      SUPERGRAPH,
+      'query { alpha(id: "1") { a b } }',
+    ).plan
 
     op1 = plan1.ops[0]
     assert_equal "alpha", op1.location
     assert_equal %|{ alpha(id: \"1\") { a b } }|, op1.selections
 
-    plan2 = GraphQL::Stitching::Planner.new(
-      supergraph: SUPERGRAPH,
-      request: GraphQL::Stitching::Request.new('query { bravo(id: "1") { a b } }'),
-    ).perform
+    plan2 = GraphQL::Stitching::Request.new(
+      SUPERGRAPH,
+      'query { bravo(id: "1") { a b } }',
+    ).plan
 
     op2 = plan2.ops[0]
     assert_equal "bravo", op2.location
@@ -68,10 +68,10 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
   end
 
   def test_delegates_remote_selections_by_unique_location_then_used_location_then_highest_availability
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: SUPERGRAPH,
-      request: GraphQL::Stitching::Request.new('query { alpha(id: "1") { a b c d e f } }'),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      SUPERGRAPH,
+      'query { alpha(id: "1") { a b c d e f } }',
+    ).plan
 
     assert_equal 3, plan.ops.length
 

--- a/test/graphql/stitching/planner/plan_delegations_test.rb
+++ b/test/graphql/stitching/planner/plan_delegations_test.rb
@@ -50,34 +50,34 @@ describe "GraphQL::Stitching::Planner, delegation strategies" do
   def test_delegates_common_fields_to_current_routing_location
     plan1 = GraphQL::Stitching::Request.new(
       SUPERGRAPH,
-      'query { alpha(id: "1") { a b } }',
+      %|query { alpha(id: "1") { a b } }|,
     ).plan
 
     op1 = plan1.ops[0]
     assert_equal "alpha", op1.location
-    assert_equal %|{ alpha(id: \"1\") { a b } }|, op1.selections
+    assert_equal %|{ alpha(id: "1") { a b } }|, op1.selections
 
     plan2 = GraphQL::Stitching::Request.new(
       SUPERGRAPH,
-      'query { bravo(id: "1") { a b } }',
+      %|query { bravo(id: "1") { a b } }|,
     ).plan
 
     op2 = plan2.ops[0]
     assert_equal "bravo", op2.location
-    assert_equal %|{ bravo(id: \"1\") { a b } }|, op2.selections
+    assert_equal %|{ bravo(id: "1") { a b } }|, op2.selections
   end
 
   def test_delegates_remote_selections_by_unique_location_then_used_location_then_highest_availability
     plan = GraphQL::Stitching::Request.new(
       SUPERGRAPH,
-      'query { alpha(id: "1") { a b c d e f } }',
+      %|query { alpha(id: "1") { a b c d e f } }|,
     ).plan
 
     assert_equal 3, plan.ops.length
 
     first = plan.ops[0]
     assert_equal "alpha", first.location
-    assert_equal %|{ alpha(id: \"1\") { a b _export_id: id _export___typename: __typename } }|, first.selections
+    assert_equal %|{ alpha(id: "1") { a b _export_id: id _export___typename: __typename } }|, first.selections
 
     second = plan.ops[1]
     assert_equal "charlie", second.location

--- a/test/graphql/stitching/planner/plan_fragments_test.rb
+++ b/test/graphql/stitching/planner/plan_fragments_test.rb
@@ -44,10 +44,7 @@ describe "GraphQL::Stitching::Planner, fragments" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 3, plan.ops.length
 
@@ -82,10 +79,7 @@ describe "GraphQL::Stitching::Planner, fragments" do
       fragment BananaAttrs on Banana { id extensions { shape } }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 3, plan.ops.length
 
@@ -146,10 +140,7 @@ describe "GraphQL::Stitching::Planner, fragments" do
 
     @supergraph = compose_definitions({ "alpha" => alpha, "bravo" => bravo })
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 3, plan.ops.length
 

--- a/test/graphql/stitching/planner/plan_introspection_test.rb
+++ b/test/graphql/stitching/planner/plan_introspection_test.rb
@@ -12,20 +12,21 @@ describe "GraphQL::Stitching::Planner, introspection" do
   end
 
   def test_plans_full_introspection_query
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(INTROSPECTION_QUERY, operation_name: "IntrospectionQuery"),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      INTROSPECTION_QUERY,
+      operation_name: "IntrospectionQuery",
+    ).plan
 
     assert_equal 1, plan.ops.length
     assert_equal "__super", plan.ops.first.location
   end
 
   def test_stitches_introspection_with_other_locations
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new("{ __schema { queryType { name } } a { name } }"),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      "{ __schema { queryType { name } } a { name } }",
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -41,10 +42,10 @@ describe "GraphQL::Stitching::Planner, introspection" do
   end
 
   def test_passes_through_typename_selections
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new("{ a { name __typename } }"),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      "{ a { name __typename } }",
+    ).plan
 
     assert_equal 1, plan.ops.length
 
@@ -56,10 +57,10 @@ describe "GraphQL::Stitching::Planner, introspection" do
 
   def test_errors_for_reserved_selection_alias
     assert_error %|Alias "_export_name" is not allowed because "_export_" is a reserved prefix| do
-      GraphQL::Stitching::Planner.new(
-        supergraph: @supergraph,
-        request: GraphQL::Stitching::Request.new("{ a { _export_name: name } }"),
-      ).perform
+      GraphQL::Stitching::Request.new(
+        @supergraph,
+        "{ a { _export_name: name } }",
+      ).plan
     end
   end
 end

--- a/test/graphql/stitching/planner/plan_introspection_test.rb
+++ b/test/graphql/stitching/planner/plan_introspection_test.rb
@@ -25,7 +25,7 @@ describe "GraphQL::Stitching::Planner, introspection" do
   def test_stitches_introspection_with_other_locations
     plan = GraphQL::Stitching::Request.new(
       @supergraph,
-      "{ __schema { queryType { name } } a { name } }",
+      %|{ __schema { queryType { name } } a { name } }|,
     ).plan
 
     assert_equal 2, plan.ops.length
@@ -44,7 +44,7 @@ describe "GraphQL::Stitching::Planner, introspection" do
   def test_passes_through_typename_selections
     plan = GraphQL::Stitching::Request.new(
       @supergraph,
-      "{ a { name __typename } }",
+      %|{ a { name __typename } }|,
     ).plan
 
     assert_equal 1, plan.ops.length
@@ -59,7 +59,7 @@ describe "GraphQL::Stitching::Planner, introspection" do
     assert_error %|Alias "_export_name" is not allowed because "_export_" is a reserved prefix| do
       GraphQL::Stitching::Request.new(
         @supergraph,
-        "{ a { _export_name: name } }",
+        %|{ a { _export_name: name } }|,
       ).plan
     end
   end

--- a/test/graphql/stitching/planner/plan_root_operations_test.rb
+++ b/test/graphql/stitching/planner/plan_root_operations_test.rb
@@ -33,10 +33,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      document,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     assert_equal 2, plan.ops.length
 
@@ -72,10 +69,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      document,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     assert_equal 3, plan.ops.length
 
@@ -129,10 +123,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      document,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     assert_equal 2, plan.ops.length
 
@@ -166,10 +157,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      document,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, document).plan
 
     assert_equal 4, plan.ops.length
 

--- a/test/graphql/stitching/planner/plan_root_operations_test.rb
+++ b/test/graphql/stitching/planner/plan_root_operations_test.rb
@@ -33,10 +33,10 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      document,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -72,10 +72,10 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      document,
+    ).plan
 
     assert_equal 3, plan.ops.length
 
@@ -129,10 +129,10 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      document,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -166,10 +166,10 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(document),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      document,
+    ).plan
 
     assert_equal 4, plan.ops.length
 
@@ -205,10 +205,8 @@ describe "GraphQL::Stitching::Planner, root operations" do
     })
 
     ["query", "mutation"].each do |operation_type|
-      planner = GraphQL::Stitching::Planner.new(
-        supergraph: supergraph,
-        request: GraphQL::Stitching::Request.new("#{operation_type} { a b c }"),
-      )
+      request = GraphQL::Stitching::Request.new(supergraph, "#{operation_type} { a b c }")
+      planner = GraphQL::Stitching::Planner.new(request)
       planner.perform
 
       first = planner.steps[0]

--- a/test/graphql/stitching/planner/plan_variables_test.rb
+++ b/test/graphql/stitching/planner/plan_variables_test.rb
@@ -34,10 +34,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      query,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -56,10 +56,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      query,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -78,10 +78,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(mutation),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      mutation,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -100,10 +100,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(mutation),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      mutation,
+    ).plan
 
     assert_equal 2, plan.ops.length
 
@@ -121,10 +121,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      query,
+    ).plan
 
     assert_equal 1, plan.ops.length
 
@@ -140,10 +140,10 @@ describe "GraphQL::Stitching::Planner, variables" do
       fragment WidgetAttrs on Widget { id name(lang: $lang) }
     |
 
-    plan = GraphQL::Stitching::Planner.new(
-      supergraph: @supergraph,
-      request: GraphQL::Stitching::Request.new(query),
-    ).perform
+    plan = GraphQL::Stitching::Request.new(
+      @supergraph,
+      query,
+    ).plan
 
     assert_equal 1, plan.ops.length
 

--- a/test/graphql/stitching/planner/plan_variables_test.rb
+++ b/test/graphql/stitching/planner/plan_variables_test.rb
@@ -34,10 +34,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      query,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 2, plan.ops.length
 
@@ -56,10 +53,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      query,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 2, plan.ops.length
 
@@ -78,10 +72,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      mutation,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, mutation).plan
 
     assert_equal 2, plan.ops.length
 
@@ -100,10 +91,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      mutation,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, mutation).plan
 
     assert_equal 2, plan.ops.length
 
@@ -121,10 +109,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      query,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 1, plan.ops.length
 
@@ -140,10 +125,7 @@ describe "GraphQL::Stitching::Planner, variables" do
       fragment WidgetAttrs on Widget { id name(lang: $lang) }
     |
 
-    plan = GraphQL::Stitching::Request.new(
-      @supergraph,
-      query,
-    ).plan
+    plan = GraphQL::Stitching::Request.new(@supergraph, query).plan
 
     assert_equal 1, plan.ops.length
 

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -225,4 +225,20 @@ describe "GraphQL::Stitching::Request" do
     expected = "query($yes: Boolean!, $no: Boolean!) { skipKeep { id } includeKeep { id } }"
     assert_equal expected, squish_string(request.document.to_query_string)
   end
+
+  def test_assigns_a_plan_for_the_request
+    plan = GraphQL::Stitching::Plan.new(ops: [])
+    request = GraphQL::Stitching::Request.new(@supergraph, "{ widget { id } }")
+
+    request.plan(plan)
+    assert_equal plan.object_id, request.plan.object_id
+  end
+
+  def test_assigning_a_plan_must_be_plan_instance
+    request = GraphQL::Stitching::Request.new(@supergraph, "{ widget { id } }")
+
+    assert_error "Plan must be a `GraphQL::Stitching::Plan`", GraphQL::Stitching::StitchingError do
+      request.plan({})
+    end
+  end
 end

--- a/test/graphql/stitching/request_test.rb
+++ b/test/graphql/stitching/request_test.rb
@@ -3,17 +3,23 @@
 require "test_helper"
 
 describe "GraphQL::Stitching::Request" do
+  def setup
+    @supergraph = {}
+  end
 
   def test_builds_with_pre_parsed_ast
     ast = GraphQL.parse("query First { widget { id } }")
-    request = GraphQL::Stitching::Request.new(ast)
+    request = GraphQL::Stitching::Request.new(@supergraph, ast)
 
     assert_equal "query", request.operation.operation_type
     assert_equal "widget", request.operation.selections.first.name
   end
 
   def test_selects_single_operation_by_default
-    request = GraphQL::Stitching::Request.new("query First { widget { id } }")
+    request = GraphQL::Stitching::Request.new(
+      @supergraph,
+      "query First { widget { id } }",
+    )
 
     assert_equal "query", request.operation.operation_type
     assert_equal "widget", request.operation.selections.first.name
@@ -25,9 +31,9 @@ describe "GraphQL::Stitching::Request" do
       query Second { sprocket { id } }
       mutation Third { makeSprocket(id: "1") { id } }
     |
-    request1 = GraphQL::Stitching::Request.new(query, operation_name: "First")
-    request2 = GraphQL::Stitching::Request.new(query, operation_name: "Second")
-    request3 = GraphQL::Stitching::Request.new(query, operation_name: "Third")
+    request1 = GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "First")
+    request2 = GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "Second")
+    request3 = GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "Third")
 
     assert_equal "query", request1.operation.operation_type
     assert_equal "query", request2.operation.operation_type
@@ -41,7 +47,7 @@ describe "GraphQL::Stitching::Request" do
     query = "query First { widget { id } } query Second { sprocket { id } }"
 
     assert_error "An operation name is required", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new(query).operation
+      GraphQL::Stitching::Request.new(@supergraph, query).operation
     end
   end
 
@@ -49,13 +55,13 @@ describe "GraphQL::Stitching::Request" do
     query = "query First { widget { id } } query Second { sprocket { id } }"
 
     assert_error "Invalid root operation", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new(query, operation_name: "Invalid").operation
+      GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "Invalid").operation
     end
   end
 
   def test_operation_errors_for_invalid_operation_types
     assert_error "Invalid root operation", GraphQL::ExecutionError do
-      GraphQL::Stitching::Request.new("subscription { movie }").operation
+      GraphQL::Stitching::Request.new(@supergraph, "subscription { movie }").operation
     end
   end
 
@@ -65,8 +71,8 @@ describe "GraphQL::Stitching::Request" do
       mutation Second @alpha(a: 1) @bravo(b: true) { makeSprocket(id: "1") { id } }
     |
 
-    request1 = GraphQL::Stitching::Request.new(query, operation_name: "First")
-    request2 = GraphQL::Stitching::Request.new(query, operation_name: "Second")
+    request1 = GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "First")
+    request2 = GraphQL::Stitching::Request.new(@supergraph, query, operation_name: "Second")
 
     assert_equal %|@inContext(lang: "EN")|, request1.operation_directives
     assert_equal %|@alpha(a: 1) @bravo(b: true)|, request2.operation_directives
@@ -78,7 +84,7 @@ describe "GraphQL::Stitching::Request" do
         widget(ids: $ids, ns: $ns) { id name(lang: $lang) }
       }
     |
-    request = GraphQL::Stitching::Request.new(query)
+    request = GraphQL::Stitching::Request.new(@supergraph, query)
     variables = request.variable_definitions.each_with_object({}) do |(name, type), memo|
       memo[name] = GraphQL::Language::Printer.new.print(type)
     end
@@ -98,7 +104,7 @@ describe "GraphQL::Stitching::Request" do
       fragment WidgetAttrs on Widget { widget }
       fragment SprocketAttrs on Sprocket { sprocket }
     |
-    request = GraphQL::Stitching::Request.new(query)
+    request = GraphQL::Stitching::Request.new(@supergraph, query)
 
     assert_equal "widget", request.fragment_definitions["WidgetAttrs"].selections.first.name
     assert_equal "sprocket", request.fragment_definitions["SprocketAttrs"].selections.first.name
@@ -111,15 +117,14 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    document = GraphQL.parse(string)
-    request = GraphQL::Stitching::Request.new(string)
+    request = GraphQL::Stitching::Request.new(@supergraph, string)
     assert_equal string, request.string
     assert_equal GraphQL.parse(string).to_query_string, request.normalized_string
   end
 
   def test_provides_string_and_normalized_string_for_parsed_ast_input
     document = GraphQL.parse("query { things { name } }")
-    request = GraphQL::Stitching::Request.new(document)
+    request = GraphQL::Stitching::Request.new(@supergraph, document)
     expected = document.to_query_string
 
     assert_equal expected, request.string
@@ -133,7 +138,7 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    request = GraphQL::Stitching::Request.new(string)
+    request = GraphQL::Stitching::Request.new(@supergraph, string)
     expected = "ad4b4eb706f67020084a7927ed5bd73b7196e393e0af3535d25ae2d22df33232"
     expected_normalized = "88908d0790f7b20afe4a7508a8bba6343c62f98abb9c5abff17345c64d90c0d0"
 
@@ -148,7 +153,7 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: { "a" => "yes" })
+    request = GraphQL::Stitching::Request.new(@supergraph, GraphQL.parse(query), variables: { "a" => "yes" })
     request.prepare!
 
     expected = { "a" => "yes", "b" => "defaultB" }
@@ -163,7 +168,7 @@ describe "GraphQL::Stitching::Request" do
     |
 
     variables = { "a" => true, "b" => false, "c" => false }
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: variables)
+    request = GraphQL::Stitching::Request.new(@supergraph, GraphQL.parse(query), variables: variables)
     request.prepare!
 
     expected = { "a" => true, "b" => false, "c" => false }
@@ -178,7 +183,7 @@ describe "GraphQL::Stitching::Request" do
     |
 
     variables = {}
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: variables)
+    request = GraphQL::Stitching::Request.new(@supergraph, GraphQL.parse(query), variables: variables)
     request.prepare!
 
     expected = { "b" => false }
@@ -195,7 +200,7 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query))
+    request = GraphQL::Stitching::Request.new(@supergraph, GraphQL.parse(query))
     request.prepare!
 
     assert_equal "query { skipKeep { id } includeKeep { id } }", squish_string(request.document.to_query_string)
@@ -211,7 +216,10 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    request = GraphQL::Stitching::Request.new(GraphQL.parse(query), variables: { "yes" => true, "no" => false })
+    request = GraphQL::Stitching::Request.new(@supergraph, GraphQL.parse(query), variables: {
+      "yes" => true,
+      "no" => false,
+    })
     request.prepare!
 
     expected = "query($yes: Boolean!, $no: Boolean!) { skipKeep { id } includeKeep { id } }"

--- a/test/graphql/stitching/shaper/grooming_test.rb
+++ b/test/graphql/stitching/shaper/grooming_test.rb
@@ -8,9 +8,8 @@ describe "GraphQL::Stitching::Shaper, grooming" do
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     request = GraphQL::Stitching::Request.new(
       supergraph_from_schema(schema_sdl),
-      "{ test { __typename req opt } }",
+      %|{ test { __typename req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -28,7 +27,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       }
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_adds_missing_fields
@@ -37,7 +36,6 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema_sdl),
       "{ test { req opt } }",
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -52,7 +50,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       }
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_grooms_through_inline_fragments
@@ -70,7 +68,6 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema_sdl),
       query,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -85,7 +82,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       }
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_grooms_through_fragment_spreads
@@ -99,7 +96,6 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema_sdl),
       query,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -114,7 +110,7 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       }
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_renames_root_query_typenames
@@ -131,11 +127,10 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema_sdl),
       source,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = { "__typename" => "QueryRoot", "typename1" => "QueryRoot", "typename2" => "QueryRoot" }
     expected = { "__typename" => "Query", "typename1" => "Query", "typename2" => "Query" }
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_renames_root_mutation_typenames
@@ -152,11 +147,10 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema_sdl),
       source,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = { "__typename" => "MutationRoot", "typename1" => "MutationRoot", "typename2" => "MutationRoot" }
     expected = { "__typename" => "Mutation", "typename1" => "Mutation", "typename2" => "Mutation" }
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_handles_introspection_types
@@ -166,9 +160,8 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       supergraph_from_schema(schema),
       INTROSPECTION_QUERY,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = schema.execute(query: INTROSPECTION_QUERY).to_h
-    assert shaper.perform!(raw)
+    assert GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 end

--- a/test/graphql/stitching/shaper/grooming_test.rb
+++ b/test/graphql/stitching/shaper/grooming_test.rb
@@ -6,10 +6,11 @@ require_relative "../../../schemas/introspection"
 describe "GraphQL::Stitching::Shaper, grooming" do
   def test_prunes_stitching_fields
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { __typename req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      "{ test { __typename req opt } }",
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -32,10 +33,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
 
   def test_adds_missing_fields
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      "{ test { req opt } }",
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -64,10 +66,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
         }
       }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(query),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      query,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -92,10 +95,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
       fragment Test1 on Test { req opt }
       fragment Test2 on Test { ...Test1 }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(query),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      query,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export_req" => "yes",
@@ -123,10 +127,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
         ...RootAttrs
       }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(source),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      source,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = { "__typename" => "QueryRoot", "typename1" => "QueryRoot", "typename2" => "QueryRoot" }
     expected = { "__typename" => "Query", "typename1" => "Query", "typename2" => "Query" }
@@ -143,10 +148,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
         ...RootAttrs
       }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(source),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      source,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = { "__typename" => "MutationRoot", "typename1" => "MutationRoot", "typename2" => "MutationRoot" }
     expected = { "__typename" => "Mutation", "typename1" => "Mutation", "typename2" => "Mutation" }
@@ -156,10 +162,11 @@ describe "GraphQL::Stitching::Shaper, grooming" do
   def test_handles_introspection_types
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
     schema = GraphQL::Schema.from_definition(schema_sdl)
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema),
-      request: GraphQL::Stitching::Request.new(INTROSPECTION_QUERY),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema),
+      INTROSPECTION_QUERY,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
 
     raw = schema.execute(query: INTROSPECTION_QUERY).to_h
     assert shaper.perform!(raw)

--- a/test/graphql/stitching/shaper/null_bubbling_test.rb
+++ b/test/graphql/stitching/shaper/null_bubbling_test.rb
@@ -9,7 +9,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => "yes",
@@ -23,7 +22,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       }
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_single_object_scopes
@@ -32,7 +31,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => nil,
@@ -41,7 +39,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
     }
     expected = { "test" => nil }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_recursive_object_scopes
@@ -50,7 +48,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => nil,
@@ -58,7 +55,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       }
     }
 
-    assert_nil shaper.perform!(raw)
+    assert_nil GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_basic_list_structure
@@ -67,7 +64,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -81,7 +77,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_list_elements
@@ -90,7 +86,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -104,7 +99,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_required_list_elements
@@ -113,7 +108,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -124,7 +118,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       "test" => nil,
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_required_lists
@@ -133,7 +127,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -141,7 +134,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_nil shaper.perform!(raw)
+    assert_nil GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_basic_nested_list_structure
@@ -150,7 +143,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -164,7 +156,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_nested_list_elements
@@ -173,7 +165,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -187,7 +178,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_nested_required_list_elements
@@ -196,7 +187,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -210,7 +200,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_for_inner_required_lists
@@ -219,7 +209,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -230,7 +219,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       "test" => nil
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubbles_null_through_nested_required_list_scopes
@@ -239,7 +228,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       %|{ test { req opt } }|,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -247,7 +235,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       ]
     }
 
-    assert_nil shaper.perform!(raw)
+    assert_nil GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubble_through_inline_fragment
@@ -265,7 +253,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       query,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export___typename" => "Test",
@@ -277,7 +264,7 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       "test" => nil
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 
   def test_bubble_through_fragment_spreads
@@ -291,7 +278,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       supergraph_from_schema(schema_sdl),
       query,
     )
-    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export___typename" => "Test",
@@ -303,6 +289,6 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       "test" => nil
     }
 
-    assert_equal expected, shaper.perform!(raw)
+    assert_equal expected, GraphQL::Stitching::Shaper.new(request).perform!(raw)
   end
 end

--- a/test/graphql/stitching/shaper/null_bubbling_test.rb
+++ b/test/graphql/stitching/shaper/null_bubbling_test.rb
@@ -5,10 +5,11 @@ require "test_helper"
 describe "GraphQL::Stitching::Shaper, null bubbling" do
   def test_basic_object_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => "yes",
@@ -27,10 +28,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_single_object_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => nil,
@@ -44,10 +46,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_recursive_object_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: Test! }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "req" => nil,
@@ -60,10 +63,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_basic_list_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -82,10 +86,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -104,10 +109,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_required_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test!] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -123,10 +129,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_required_lists
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [Test!]! }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         { "req" => "yes", "opt" => nil },
@@ -139,10 +146,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_basic_nested_list_structure
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test]] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -161,10 +169,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_nested_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test]] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -183,10 +192,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_nested_required_list_elements
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -205,10 +215,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_for_inner_required_lists
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]!] }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -224,10 +235,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
 
   def test_bubbles_null_through_nested_required_list_scopes
     schema_sdl = "type Test { req: String! opt: String } type Query { test: [[Test!]!]! }"
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new("{ test { req opt } }"),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      %|{ test { req opt } }|,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => [
         [{ "req" => "yes", "opt" => nil }],
@@ -249,10 +261,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
         }
       }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(query),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      query,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export___typename" => "Test",
@@ -274,10 +287,11 @@ describe "GraphQL::Stitching::Shaper, null bubbling" do
       fragment Test1 on Test { req opt }
       fragment Test2 on Test { ...Test1 }
     |
-    shaper = GraphQL::Stitching::Shaper.new(
-      supergraph: supergraph_from_schema(schema_sdl),
-      request: GraphQL::Stitching::Request.new(query),
+    request = GraphQL::Stitching::Request.new(
+      supergraph_from_schema(schema_sdl),
+      query,
     )
+    shaper = GraphQL::Stitching::Shaper.new(request)
     raw = {
       "test" => {
         "_export___typename" => "Test",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,19 +58,14 @@ def supergraph_from_schema(schema, fields: {}, boundaries: {}, executables: {})
 end
 
 def plan_and_execute(supergraph, query, variables={}, raw: false)
-  request = GraphQL::Stitching::Request.new(query, variables: variables)
-
-  plan = GraphQL::Stitching::Planner.new(
-    supergraph: supergraph,
-    request: request,
-  ).perform
-
-  executor = GraphQL::Stitching::Executor.new(
-    supergraph: supergraph,
-    request: request,
-    plan: plan,
+  request = GraphQL::Stitching::Request.new(
+    supergraph,
+    query,
+    variables: variables,
   )
 
+  plan = request.plan
+  executor = GraphQL::Stitching::Executor.new(request)
   result = executor.perform(raw: raw)
 
   yield(plan, executor) if block_given?


### PR DESCRIPTION
⚠️ **Minor breaking change**

This gives a `supergraph` reference to `Request`, and then refactors `Planner`, `Executor`, and `Shaper` to simply wrap a request. 

This shift makes requests act as the central hub of operations, similar to `Query` in GraphQL Ruby. This sets requests up to handle more contextual concerns such as visibility and authorization.

**Migration steps**

1. See doc changes in PR.
2. `Request` now takes a supergraph instance as its first required argument.
3. `Planner`, `Executor`, and `Shaper` now simply take a request argument. Better yet, don't use these components directly and invoke their behaviors through the request.