### PR TITLE
Better GraphQL Ruby version handling

### DIFF
--- a/lib/graphql/stitching/export_selection.rb
+++ b/lib/graphql/stitching/export_selection.rb
@@ -20,8 +20,13 @@ module GraphQL
           "#{EXPORT_PREFIX}#{name}"
         end
 
+        # The argument assigning Field.alias changed from
+        # a generic `alias` hash key to a structured `field_alias` kwarg.
+        # See https://github.com/rmosolgo/graphql-ruby/pull/4718
+        FIELD_ALIAS_KWARG = !GraphQL::Language::Nodes::Field.new(field_alias: "a").alias.nil?
+
         def key_node(field_name)
-          if Util.graphql_version?(2, 2)
+          if FIELD_ALIAS_KWARG
             GraphQL::Language::Nodes::Field.new(field_alias: key(field_name), name: field_name)
           else
             GraphQL::Language::Nodes::Field.new(alias: key(field_name), name: field_name)

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -12,16 +12,7 @@ module GraphQL
         end
       end
 
-      GRAPHQL_VERSION = GraphQL::VERSION.split(".").map(&:to_i).freeze
-
       class << self
-        def graphql_version?(major, minor = nil, patch = nil)
-          result = GRAPHQL_VERSION[0] >= major
-          result &&= GRAPHQL_VERSION[1] >= minor if minor
-          result &&= GRAPHQL_VERSION[2] >= patch if patch
-          result
-        end
-
         # specifies if a type is a primitive leaf value
         def is_leaf_type?(type)
           type.kind.scalar? || type.kind.enum?


### PR DESCRIPTION
Improves upon a precedent for chaotic version checking started in https://github.com/gmac/graphql-stitching-ruby/pull/105. 