### PR TITLE
Send `request` to executables in place of `context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,11 +360,11 @@ It's perfectly fine to mix and match schemas that implement an `_entities` query
 
 ## Executables
 
-An executable resource performs location-specific GraphQL requests. Executables may be `GraphQL::Schema` classes, or any object that responds to `.call(location, source, variables, context)` and returns a raw GraphQL response:
+An executable resource performs location-specific GraphQL requests. Executables may be `GraphQL::Schema` classes, or any object that responds to `.call(location, source, variables, request)` and returns a raw GraphQL response:
 
 ```ruby
 class MyExecutable
-  def call(location, source, variables, context)
+  def call(location, source, variables, request)
     # process a GraphQL request...
     return {
       "data" => { ... },
@@ -392,7 +392,7 @@ supergraph = GraphQL::Stitching::Composer.new.perform({
   },
   fourth: {
     schema: FourthSchema,
-    executable: ->(loc, query, vars, ctx) { ... },
+    executable: ->(loc, query, vars, req) { ... },
   },
 })
 ```

--- a/lib/graphql/stitching/executor/boundary_source.rb
+++ b/lib/graphql/stitching/executor/boundary_source.rb
@@ -29,7 +29,7 @@ module GraphQL
             @executor.request.operation_directives,
           )
           variables = @executor.request.variables.slice(*variable_names)
-          raw_result = @executor.supergraph.execute_at_location(@location, query_document, variables, @executor.request.context)
+          raw_result = @executor.supergraph.execute_at_location(@location, query_document, variables, @executor.request)
           @executor.query_count += 1
 
           merge_results!(origin_sets_by_operation, raw_result.dig("data"))

--- a/lib/graphql/stitching/executor/root_source.rb
+++ b/lib/graphql/stitching/executor/root_source.rb
@@ -17,7 +17,7 @@ module GraphQL
           @executor.request.operation_directives,
         )
         query_variables = @executor.request.variables.slice(*op.variables.keys)
-        result = @executor.supergraph.execute_at_location(op.location, query_document, query_variables, @executor.request.context)
+        result = @executor.supergraph.execute_at_location(op.location, query_document, query_variables, @executor.request)
         @executor.query_count += 1
 
         @executor.data.merge!(result["data"]) if result["data"]

--- a/lib/graphql/stitching/http_executable.rb
+++ b/lib/graphql/stitching/http_executable.rb
@@ -12,7 +12,7 @@ module GraphQL
         @headers = { "Content-Type" => "application/json" }.merge!(headers)
       end
 
-      def call(_location, document, variables, _context)
+      def call(_location, document, variables, _request)
         response = Net::HTTP.post(
           URI(@url),
           JSON.generate({ "query" => document, "variables" => variables }),

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -209,7 +209,7 @@ module GraphQL
         end
       end
 
-      def execute_at_location(location, source, variables, context)
+      def execute_at_location(location, source, variables, request)
         executable = executables[location]
 
         if executable.nil?
@@ -218,11 +218,11 @@ module GraphQL
           executable.execute(
             query: source,
             variables: variables,
-            context: context.frozen? ? context.dup : context,
+            context: request.context.frozen? ? request.context.dup : request.context,
             validate: false,
           )
         elsif executable.respond_to?(:call)
-          executable.call(location, source, variables, context)
+          executable.call(location, source, variables, request)
         else
           raise StitchingError, "Missing valid executable for #{location} location."
         end


### PR DESCRIPTION
⚠️ **Minor breaking change**

This adjusts the call signature of the `Executable` interface to receive a `request` object rather than `context`. A [Request](https://github.com/gmac/graphql-stitching-ruby/blob/main/docs/request.md) object is considerably more useful because it (will soon) [include schema/supergraph information](https://github.com/gmac/graphql-stitching-ruby/pull/104), and also provides context. This will enable executables to be a whole lot smarter.

**Migration steps**

1. See doc changes in PR.
2. The former `context` argument can now be accessed via `request.context`.