### PR TITLE
Shift validation to Request object

### DIFF
--- a/lib/graphql/stitching/client.rb
+++ b/lib/graphql/stitching/client.rb
@@ -36,7 +36,7 @@ module GraphQL
         )
 
         if validate
-          validation_errors = @supergraph.schema.validate(request.document)
+          validation_errors = request.validate
           return error_result(validation_errors) if validation_errors.any?
         end
 

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -85,6 +85,10 @@ module GraphQL
         end
       end
 
+      def validate
+        @supergraph.schema.validate(@document, context: @context)
+      end
+
       def prepare!
         operation.variables.each do |v|
           @variables[v.name] = v.default_value if @variables[v.name].nil? && !v.default_value.nil?


### PR DESCRIPTION
Adds a `validate` method directly to Request objects.