### PR TITLE
Reorder Executable `call` args

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ It's perfectly fine to mix and match schemas that implement an `_entities` query
 
 ## Executables
 
-An executable resource performs location-specific GraphQL requests. Executables may be `GraphQL::Schema` classes, or any object that responds to `.call(location, source, variables, request)` and returns a raw GraphQL response:
+An executable resource performs location-specific GraphQL requests. Executables may be `GraphQL::Schema` classes, or any object that responds to `.call(request, source, variables)` and returns a raw GraphQL response:
 
 ```ruby
 class MyExecutable
-  def call(location, source, variables, request)
+  def call(request, source, variables)
     # process a GraphQL request...
     return {
       "data" => { ... },
@@ -394,7 +394,7 @@ supergraph = GraphQL::Stitching::Composer.new.perform({
   },
   fourth: {
     schema: FourthSchema,
-    executable: ->(loc, query, vars, req) { ... },
+    executable: ->(req, query, vars) { ... },
   },
 })
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Major components include:
 - [Request](./request.md) - prepares a requested GraphQL document and variables for stitching.
 - [Planner](./planner.md) - builds a cacheable query plan for a request document.
 - [Executor](./executor.md) - executes a query plan with given request variables.
+- [HttpExecutable](./http_executable.md) - proxies requests to remotes with multipart file upload support.
 
 Additional topics:
 

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -90,7 +90,7 @@ Location settings have top-level keys that specify arbitrary location names, eac
 
 - **`schema:`** _required_, provides a `GraphQL::Schema` class for the location. This may be a class-based schema that inherits from `GraphQL::Schema`, or built from SDL (Schema Definition Language) string using `GraphQL::Schema.from_definition` and mapped to a remote location. The provided schema is only used for type reference and does not require any real data resolvers (unless it is also used as the location's executable, see below).
 
-- **`executable:`** _optional_, provides an executable resource to be called when delegating a request to this location. Executables are `GraphQL::Schema` classes or any object with a `.call(location, source, variables, context)` method that returns a GraphQL response. Omitting the executable option will use the location's provided `schema` as the executable resource.
+- **`executable:`** _optional_, provides an executable resource to be called when delegating a request to this location. Executables are `GraphQL::Schema` classes or any object with a `.call(request, source, variables)` method that returns a GraphQL response. Omitting the executable option will use the location's provided `schema` as the executable resource.
 
 - **`stitch:`** _optional_, an array of configs used to dynamically apply `@stitch` directives to select root fields prior to composing. This is useful when you can't easily render stitching directives into a location's source schema.
 

--- a/lib/graphql/stitching/http_executable.rb
+++ b/lib/graphql/stitching/http_executable.rb
@@ -13,9 +13,9 @@ module GraphQL
         @upload_types = upload_types
       end
 
-      def call(_location, document, variables, request)
+      def call(request, document, variables)
         multipart_form = if request.variable_definitions.any? && variables&.any?
-          extract_multipart_form(document, variables, request)
+          extract_multipart_form(request, document, variables)
         end
 
         response = if multipart_form
@@ -50,7 +50,7 @@ module GraphQL
 
       # extract multipart upload forms
       # spec: https://github.com/jaydenseric/graphql-multipart-request-spec
-      def extract_multipart_form(document, variables, request)
+      def extract_multipart_form(request, document, variables)
         return unless @upload_types
 
         path = []

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -222,7 +222,7 @@ module GraphQL
             validate: false,
           )
         elsif executable.respond_to?(:call)
-          executable.call(location, source, variables, request)
+          executable.call(request, source, variables)
         else
           raise StitchingError, "Missing valid executable for #{location} location."
         end

--- a/test/graphql/stitching/executor/executor_test.rb
+++ b/test/graphql/stitching/executor/executor_test.rb
@@ -19,15 +19,15 @@ describe "GraphQL::Stitching::Executor" do
     supergraph = GraphQL::Stitching::Composer.new.perform({
       alpha: {
         schema: GraphQL::Schema.from_definition(alpha),
-        executable: -> (loc, src, vars, ctx) {
-          results << { location: loc, source: src }
+        executable: -> (req, src, vars) {
+          results << { location: "alpha", source: src }
           { "data" => returns.shift }
         },
       },
       bravo: {
         schema: GraphQL::Schema.from_definition(bravo),
-        executable: -> (loc, src, vars, ctx) {
-          results << { location: loc, source: src }
+        executable: -> (req, src, vars) {
+          results << { location: "bravo", source: src }
           { "data" => returns.shift }
         },
       },

--- a/test/graphql/stitching/http_executable_test.rb
+++ b/test/graphql/stitching/http_executable_test.rb
@@ -70,7 +70,7 @@ describe "GraphQL::Stitching::HttpExecutable" do
       upload_types: ["Upload"],
     )
 
-    result = exe.extract_multipart_form(document, variables, request).tap do |r|
+    result = exe.extract_multipart_form(request, document, variables).tap do |r|
       r["operations"] = JSON.parse(r["operations"])
       r["map"] = JSON.parse(r["map"])
     end


### PR DESCRIPTION
⚠️ **Minor breaking change**

This reorders and reduces `Executable.call` arguments. The method signature is now:

```ruby
Executable.call(request, document, variables)
```

Changes to note:

- `request` is now the first argument.
- former `context` argument has been removed in favor of `request.context`.
- former `location` argument has been removed without replacement, as executables should have implicit awareness of their assigned target.
