### PR TITLE
Fix error repathing for object namespaces

### DIFF
--- a/lib/graphql/stitching/executor/boundary_source.rb
+++ b/lib/graphql/stitching/executor/boundary_source.rb
@@ -183,9 +183,7 @@ module GraphQL::Stitching
           end
 
         elsif forward_path.any?
-          current_path << index
           repath_errors!(pathed_errors_by_object_id, forward_path, current_path, scope)
-          current_path.pop
 
         elsif scope.is_a?(Array)
           scope.each_with_index do |element, index|

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end

--- a/test/schemas/errors.rb
+++ b/test/schemas/errors.rb
@@ -9,9 +9,18 @@ module Schemas
       repeatable true
     end
 
+    ISOTOPES_A = [
+      { id: '1', name: 'Ne20' },
+      { id: '2', name: 'Kr79' },
+    ].freeze
+
+    ISOTOPES_B = [
+      { id: '2', halflife: '35d' },
+    ].freeze
+
     ELEMENTS_A = [
-      { id: '10', name: 'neon' },
-      { id: '36', name: 'krypton' },
+      { id: '10', name: 'neon', isotopes: [ISOTOPES_A[0]], isotope: ISOTOPES_A[0] },
+      { id: '36', name: 'krypton', isotopes: [ISOTOPES_A[1]], isotope: ISOTOPES_A[1] },
     ].freeze
 
     ELEMENTS_B = [
@@ -20,9 +29,16 @@ module Schemas
     ].freeze
 
     class ElementsA < GraphQL::Schema
+      class Isotope < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :name, String, null: false
+      end
+
       class Element < GraphQL::Schema::Object
         field :id, ID, null: false
         field :name, String, null: false
+        field :isotopes, [Isotope, null: true], null: false
+        field :isotope, Isotope, null: true
       end
 
       class Query < GraphQL::Schema::Object
@@ -36,12 +52,34 @@ module Schemas
             ELEMENTS_A.find { _1[:id] == id } || GraphQL::ExecutionError.new("Not found")
           end
         end
+
+        field :element_a, Element, null: true do
+          argument :id, ID, required: true
+        end
+
+        def element_a(id:)
+          ELEMENTS_A.find { _1[:id] == id } || GraphQL::ExecutionError.new("Not found")
+        end
+
+        field :isotope_a, Isotope, null: true do
+          directive Boundary, key: "id"
+          argument :id, ID, required: true
+        end
+
+        def isotope_a(id:)
+          ISOTOPES_A.find { _1[:id] == id } || GraphQL::ExecutionError.new("Not found")
+        end
       end
 
       query Query
     end
 
     class ElementsB < GraphQL::Schema
+      class Isotope < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :halflife, String, null: false
+      end
+
       class Element < GraphQL::Schema::Object
         field :id, ID, null: false
         field :code, String, null: true
@@ -58,6 +96,15 @@ module Schemas
           ids.map do |id|
             ELEMENTS_B.find { _1[:id] == id } || GraphQL::ExecutionError.new("Not found")
           end
+        end
+
+        field :isotope_b, Isotope, null: true do
+          directive Boundary, key: "id"
+          argument :id, ID, required: true
+        end
+
+        def isotope_b(id:)
+          ISOTOPES_B.find { _1[:id] == id } || GraphQL::ExecutionError.new("Not found")
         end
       end
 


### PR DESCRIPTION
As reported by @shyouhei in https://github.com/gmac/graphql-stitching-ruby/issues/117, there's a copy and paste mistake in error repathing that breaks while traversing object namespaces. Thanks for the report, simple fix. Definitely needed more tests.

Resolves https://github.com/gmac/graphql-stitching-ruby/issues/117.