### PR TITLE
Smarter boundary arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ type Query {
 }
 ```
 
-To customize which types a query provides, you may extend the `@stitch` directive with a `__typename` argument and then declare keys for select types.
+To customize which types an abstract query provides, you may extend the `@stitch` directive with a `__typename` argument to target a specific type. This can be repeated to target multiple types.
 
 ```graphql
 directive @stitch(key: String!, __typename: String) repeatable on FIELD_DEFINITION
@@ -213,13 +213,15 @@ type Query {
 
 #### Multiple query arguments
 
-Stitching infers which argument to use for queries with a single argument. For queries that accept multiple arguments, the key must provide an argument mapping specified as `"<arg>:<key>"`. Note the `"id:id"` key:
+Stitching infers which argument to use for queries with a single argument. For queries that accept multiple arguments, the key may provide an argument mapping specified as `"<arg>:<key>"`. Note the `"id:id"` key:
 
 ```graphql
 type Query {
   product(id: ID, upc: ID): Product @stitch(key: "id:id")
 }
 ```
+
+This argument mapping is optional when the key name matches its intended argument.
 
 #### Multiple type keys
 
@@ -252,7 +254,7 @@ type Product {
   upc: ID!
 }
 type Query {
-  product(id: ID, upc: ID): Product @stitch(key: "id:id") @stitch(key: "upc:upc")
+  product(id: ID, upc: ID): Product @stitch(key: "id") @stitch(key: "upc")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ See [error handling](./docs/mechanics.md#stitched-errors) tips for list queries.
 
 #### Abstract queries
 
-It's okay for stitching queries to be implemented through abstract types. An abstract query will provide access to all of its possible types. For interfaces, the key selection should match a field within the interface. For unions, all possible types must implement the key selection individually.
+It's okay for stitching queries to be implemented through abstract types. An abstract query will provide access to all of its possible types by default, each of which must implement the named key selection.
 
 ```graphql
 interface Node {
@@ -194,6 +194,21 @@ type Product implements Node {
 }
 type Query {
   nodes(ids: [ID!]!): [Node]! @stitch(key: "id")
+}
+```
+
+To customize which types a query provides (useful for unions), you may extend the `@stitch` directive with a `__typename` argument and then declare keys for a limited set of types.
+
+```graphql
+directive @stitch(key: String!, __typename: String) repeatable on FIELD_DEFINITION
+
+type Product { upc: ID! }
+type Order { id: ID! }
+type Discount { code: ID! }
+union Entity = Product | Order | Discount
+
+type Query {
+  entity(key: ID!): Entity @stitch(key: "upc", __typename: "Product") @stitch(key: "id", __typename: "Order")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,18 +197,17 @@ type Query {
 }
 ```
 
-To customize which types a query provides (useful for unions), you may extend the `@stitch` directive with a `__typename` argument and then declare keys for a limited set of types.
+To customize which types a query provides, you may extend the `@stitch` directive with a `__typename` argument and then declare keys for select types.
 
 ```graphql
 directive @stitch(key: String!, __typename: String) repeatable on FIELD_DEFINITION
 
-type Product { upc: ID! }
+type Product { id: ID! }
 type Order { id: ID! }
-type Discount { code: ID! }
-union Entity = Product | Order | Discount
+union Entity = Product | Order
 
 type Query {
-  entity(key: ID!): Entity @stitch(key: "upc", __typename: "Product") @stitch(key: "id", __typename: "Order")
+  entity(key: ID!): Entity @stitch(key: "id", __typename: "Product")
 }
 ```
 

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -577,12 +577,13 @@ module GraphQL
               argument_name = key_selections[0].alias
               argument_name ||= if field_candidate.arguments.size == 1
                 field_candidate.arguments.keys.first
+              elsif field_candidate.arguments[key]
+                key
               end
 
               argument = field_candidate.arguments[argument_name]
               unless argument
-                # contextualize this... "boundaries with multiple args need mapping aliases."
-                raise ComposerError, "Invalid boundary argument `#{argument_name}` for #{type_name}.#{field_name}."
+                raise ComposerError, "No boundary argument matched for #{type_name}.#{field_name}.#{argument_name}. Specify a key alias."
               end
 
               argument_structure = Util.flatten_type_structure(argument.type)

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/test/graphql/stitching/composer/merge_boundaries_test.rb
+++ b/test/graphql/stitching/composer/merge_boundaries_test.rb
@@ -44,7 +44,7 @@ describe 'GraphQL::Stitching::Composer, merging boundary queries' do
     |
     b = %|
       type T { id:ID! upc:ID! }
-      type Query { b(id: ID, upc:ID):T @stitch(key: "id:id") @stitch(key: "upc:upc") }
+      type Query { b(id: ID, code:ID):T @stitch(key: "id") @stitch(key: "code:upc") }
     |
     c = %|
       type T { id:ID! }
@@ -54,7 +54,7 @@ describe 'GraphQL::Stitching::Composer, merging boundary queries' do
     supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c })
 
     assert_boundary(supergraph, "T", location: "a", key: "upc", field: "a", arg: "upc")
-    assert_boundary(supergraph, "T", location: "b", key: "upc", field: "b", arg: "upc")
+    assert_boundary(supergraph, "T", location: "b", key: "upc", field: "b", arg: "code")
     assert_boundary(supergraph, "T", location: "b", key: "id", field: "b", arg: "id")
     assert_boundary(supergraph, "T", location: "c", key: "id", field: "c", arg: "id")
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ require 'graphql/stitching'
 
 ComposerError = GraphQL::Stitching::Composer::ComposerError
 ValidationError = GraphQL::Stitching::Composer::ValidationError
-STITCH_DEFINITION = "directive @stitch(key: String!) repeatable on FIELD_DEFINITION\n"
+STITCH_DEFINITION = "directive @stitch(key: String!, __typename: String, federation: Boolean=false) repeatable on FIELD_DEFINITION\n"
 
 def squish_string(str)
   str.gsub(/\s+/, " ").strip


### PR DESCRIPTION
Allows `@stitch` directives to specify a `__typename` argument so that abstracts can select which types to include using what key.