### PR TITLE
Fix nested root scopes

### DIFF
--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/test/graphql/stitching/integration/nested_root_test.rb
+++ b/test/graphql/stitching/integration/nested_root_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../schemas/nested_root"
+
+describe 'GraphQL::Stitching, nested root scopes' do
+  def setup
+    @supergraph = compose_definitions({
+      "a" => Schemas::NestedRoot::Alpha,
+      "b" => Schemas::NestedRoot::Bravo,
+    })
+  end
+
+  def test_nested_root_scopes
+    source = %|
+      mutation {
+        doStuff {
+          apple
+          banana
+        }
+      }
+    |
+
+    expected = {
+      "doStuff" => {
+        "apple" => "red",
+        "banana" => "yellow",
+      }
+    }
+
+    result = plan_and_execute(@supergraph, source)
+    assert_equal expected, result["data"]
+  end
+
+  def test_nested_root_scopes_with_complex_paths
+    source = %|
+      mutation {
+        doThings {
+          query {
+            apple
+            banana
+          }
+        }
+      }
+    |
+
+    expected = {
+      "doThings" => [
+        {
+          "query" => {
+            "apple" => "red",
+            "banana" => "yellow",
+          }
+        },
+        {
+          "query" => {
+            "apple" => "red",
+            "banana" => "yellow",
+          }
+        },
+      ]
+    }
+
+    result = plan_and_execute(@supergraph, source)
+    assert_equal expected, result["data"]
+  end
+
+  def test_nested_root_scopes_repath_errors
+    source = %|
+      mutation {
+        doThing {
+          query {
+            errorA
+            errorB
+          }
+        }
+      }
+    |
+
+    expected = [
+      { "message" => "a", "path" => ["doThing", "query", "errorA"] },
+      { "message" => "b", "path" => ["doThing", "query", "errorB"] },
+    ]
+
+    result = plan_and_execute(@supergraph, source)
+    assert_equal expected, result["errors"]
+  end
+end

--- a/test/schemas/nested_root.rb
+++ b/test/schemas/nested_root.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Schemas
+  module NestedRoot
+    class Alpha < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :apple, String, null: false
+        field :error_a, String, null: false
+
+        def apple
+          "red"
+        end
+
+        def error_a
+          raise GraphQL::ExecutionError.new("a")
+        end
+      end
+
+      class Thing < GraphQL::Schema::Object
+        field :query, Query, null: false
+
+        def query
+          {}
+        end
+      end
+
+      class Mutation < GraphQL::Schema::Object
+        field :do_stuff, Query, null: false
+
+        def do_stuff
+          {}
+        end
+
+        field :do_thing, Thing, null: false
+
+        def do_thing
+          {}
+        end
+
+        field :do_things, [Thing], null: false
+
+        def do_things
+          [{}, {}]
+        end
+      end
+
+      query Query
+      mutation Mutation
+    end
+
+    class Bravo < GraphQL::Schema
+      class Query < GraphQL::Schema::Object
+        field :banana, String, null: false
+        field :error_b, String, null: false
+
+        def banana
+          "yellow"
+        end
+
+        def error_b
+          raise GraphQL::ExecutionError.new("b")
+        end
+      end
+
+      query Query
+    end
+  end
+end


### PR DESCRIPTION
A schema's `Query` is just a plain old object that can be repeated lower in the graph. This fixes a bug where nested root scopes error as a merged type without a keyed boundary.