### PR TITLE
Fix orphan_types error with GraphQL Ruby 2.3.0

### DIFF
--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -145,7 +145,7 @@ module GraphQL
 
         builder = self
         schema = Class.new(GraphQL::Schema) do
-          orphan_types schema_types.values
+          add_type_and_traverse(schema_types.values, root: false)
           query schema_types[builder.query_name]
           mutation schema_types[builder.mutation_name]
           directives builder.schema_directives.values


### PR DESCRIPTION
GraphQL Ruby 2.3.0 validates incoming orphan_types are object types [1]. One of the suggested fixes is to use `add_type_and_traverse` directly, though that is a private method and not guaranteed to always work.

[1]: https://github.com/rmosolgo/graphql-ruby/pull/4869