### PR TITLE
Fix hydration of boundaries with abstract types

### DIFF
--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -31,7 +31,7 @@ module GraphQL
               kwargs = directive.arguments.keyword_arguments
               boundary_map[type_name] ||= []
               boundary_map[type_name] << Boundary.new(
-                type_name: type_name,
+                type_name: kwargs.fetch(:type_name, type_name),
                 location: kwargs[:location],
                 key: kwargs[:key],
                 field: kwargs[:field],
@@ -134,6 +134,7 @@ module GraphQL
               end
 
               type.directive(ResolverDirective, **{
+                type_name: (boundary.type_name if boundary.type_name != type_name),
                 location: boundary.location,
                 key: boundary.key,
                 field: boundary.field,

--- a/lib/graphql/stitching/supergraph/resolver_directive.rb
+++ b/lib/graphql/stitching/supergraph/resolver_directive.rb
@@ -5,6 +5,7 @@ module GraphQL::Stitching
     class ResolverDirective < GraphQL::Schema::Directive
       graphql_name "resolver"
       locations OBJECT, INTERFACE, UNION
+      argument :type_name, String, required: false
       argument :location, String, required: true
       argument :key, String, required: true
       argument :field, String, required: true


### PR DESCRIPTION
This commit ensures boundaries relying on abstract queries specify the abstract type name in the resolver directive. This is necessary to ensure the correct type is resolved when the boundary is hydrated.

I'm working on a project that stitches some types via abstract queries. I noticed that a dynamically composed version of the supergrapgh works fine, but a supergraph hydrated from the dumped SDL is generating invalid subgraph queries—it's not including the necessary inline fragment.

### Example

**Schema A**

```gql
type Query {
  nodes(ids: [ID!]!): [Node]! @stitch(key: "id")
}

type Post implements Node {
  id: ID!
  title: String!
}
```

**Schema B**

```gql
type Query {
  post(id: ID!): Post @stitch(key: "id")
}

type Post {
  id: ID!
  summary: String!
}
```

**Supergraph query**

```gql
query {
  post(id: "gid://my-app/Post/123") {
    title
    summary
  }
}
```

**Current invalid query on schema A**

```gql
query {
  _0_result: nodes(ids: ["gid://my-app/Post/123"]) {
    title
  }
}
```

**Fixed query on schema A**

```gql
query {
  _0_result: nodes(ids: ["gid://my-app/Post/123"]) {
    ... on Post
      title
    }
  }
}
```