### PR TITLE
Rename "boundary" code concept to "resolver"

### DIFF
--- a/docs/mechanics.md
+++ b/docs/mechanics.md
@@ -345,4 +345,4 @@ type Query {
 }
 ```
 
-In this graph, `Widget` is a merged type without a resolver query in location C. This works because all of its fields are resolvable in other locations; that means location C can provide outbound representations of this type without ever needing to resolve inbound requests for it. Outbound types do still require a key field (such as `id` above) that allow them to join with data in other resolver locations (such as `price` above).
+In this graph, `Widget` is a merged type without a resolver query in location C. This works because all of its fields are resolvable in other locations; that means location C can provide outbound representations of this type without ever needing to resolve inbound requests for it. Outbound types do still require a shared key field (such as `id` above) that allow them to join with data in other resolver locations (such as `price` above).

--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -24,7 +24,7 @@ module GraphQL
 end
 
 require_relative "stitching/supergraph"
-require_relative "stitching/boundary"
+require_relative "stitching/resolver"
 require_relative "stitching/client"
 require_relative "stitching/composer"
 require_relative "stitching/executor"

--- a/lib/graphql/stitching/composer/resolver_config.rb
+++ b/lib/graphql/stitching/composer/resolver_config.rb
@@ -2,7 +2,7 @@
 
 module GraphQL::Stitching
   class Composer
-    class BoundaryConfig
+    class ResolverConfig
       ENTITY_TYPENAME = "_Entity"
       ENTITIES_QUERY = "_entities"
 

--- a/lib/graphql/stitching/composer/validate_resolvers.rb
+++ b/lib/graphql/stitching/composer/validate_resolvers.rb
@@ -2,7 +2,7 @@
 
 module GraphQL::Stitching
   class Composer
-    class ValidateBoundaries < BaseValidator
+    class ValidateResolvers < BaseValidator
 
       def perform(supergraph, composer)
         supergraph.schema.types.each do |type_name, type|
@@ -15,9 +15,9 @@ module GraphQL::Stitching
           candidate_types_by_location = composer.candidate_types_by_name_and_location[type_name]
           next unless candidate_types_by_location.length > 1
 
-          boundaries = supergraph.boundaries[type_name]
-          if boundaries&.any?
-            validate_as_boundary(supergraph, type, candidate_types_by_location, boundaries)
+          resolvers = supergraph.resolvers[type_name]
+          if resolvers&.any?
+            validate_as_resolver(supergraph, type, candidate_types_by_location, resolvers)
           elsif type.kind.object?
             validate_as_shared(supergraph, type, candidate_types_by_location)
           end
@@ -26,48 +26,48 @@ module GraphQL::Stitching
 
       private
 
-      def validate_as_boundary(supergraph, type, candidate_types_by_location, boundaries)
-        # abstract boundaries are expanded with their concrete implementations, which each get validated. Ignore the abstract itself.
+      def validate_as_resolver(supergraph, type, candidate_types_by_location, resolvers)
+        # abstract resolvers are expanded with their concrete implementations, which each get validated. Ignore the abstract itself.
         return if type.kind.abstract?
 
-        # only one boundary allowed per type/location/key
-        boundaries_by_location_and_key = boundaries.each_with_object({}) do |boundary, memo|
-          if memo.dig(boundary.location, boundary.key)
-            raise Composer::ValidationError, "Multiple boundary queries for `#{type.graphql_name}.#{boundary.key}` "\
-              "found in #{boundary.location}. Limit one boundary query per type and key in each location. "\
-              "Abstract boundaries provide all possible types."
+        # only one resolver allowed per type/location/key
+        resolvers_by_location_and_key = resolvers.each_with_object({}) do |resolver, memo|
+          if memo.dig(resolver.location, resolver.key)
+            raise Composer::ValidationError, "Multiple resolver queries for `#{type.graphql_name}.#{resolver.key}` "\
+              "found in #{resolver.location}. Limit one resolver query per type and key in each location. "\
+              "Abstract resolvers provide all possible types."
           end
-          memo[boundary.location] ||= {}
-          memo[boundary.location][boundary.key] = boundary
+          memo[resolver.location] ||= {}
+          memo[resolver.location][resolver.key] = resolver
         end
 
-        boundary_keys = boundaries.map(&:key).to_set
+        resolver_keys = resolvers.map(&:key).to_set
 
-        # All non-key fields must be resolvable in at least one boundary location
+        # All non-key fields must be resolvable in at least one resolver location
         supergraph.locations_by_type_and_field[type.graphql_name].each do |field_name, locations|
-          next if boundary_keys.include?(field_name)
+          next if resolver_keys.include?(field_name)
 
-          if locations.none? { boundaries_by_location_and_key[_1] }
+          if locations.none? { resolvers_by_location_and_key[_1] }
             where = locations.length > 1 ? "one of #{locations.join(", ")} locations" : locations.first
-            raise Composer::ValidationError, "A boundary query is required for `#{type.graphql_name}` in #{where} to resolve field `#{field_name}`."
+            raise Composer::ValidationError, "A resolver query is required for `#{type.graphql_name}` in #{where} to resolve field `#{field_name}`."
           end
         end
 
-        # All locations of a boundary type must include at least one key field
+        # All locations of a resolver type must include at least one key field
         supergraph.fields_by_type_and_location[type.graphql_name].each do |location, field_names|
-          if field_names.none? { boundary_keys.include?(_1) }
-            raise Composer::ValidationError, "A boundary key is required for `#{type.graphql_name}` in #{location} to join with other locations."
+          if field_names.none? { resolver_keys.include?(_1) }
+            raise Composer::ValidationError, "A resolver key is required for `#{type.graphql_name}` in #{location} to join with other locations."
           end
         end
 
         # verify that all outbound locations can access all inbound locations
-        resolver_locations = boundaries_by_location_and_key.keys
+        resolver_locations = resolvers_by_location_and_key.keys
         candidate_types_by_location.each_key do |location|
           remote_locations = resolver_locations.reject { _1 == location }
           paths = supergraph.route_type_to_locations(type.graphql_name, location, remote_locations)
           if paths.length != remote_locations.length || paths.any? { |_loc, path| path.nil? }
-            raise Composer::ValidationError, "Cannot route `#{type.graphql_name}` boundaries in #{location} to all other locations. "\
-              "All locations must provide a boundary accessor that uses a conjoining key."
+            raise Composer::ValidationError, "Cannot route `#{type.graphql_name}` resolvers in #{location} to all other locations. "\
+              "All locations must provide a resolver query with a joining key."
           end
         end
       end
@@ -87,7 +87,7 @@ module GraphQL::Stitching
         candidate_types_by_location.each do |location, candidate_type|
           if candidate_type.fields.keys.sort != expected_fields
             raise Composer::ValidationError, "Shared type `#{type.graphql_name}` must have consistent fields across locations, "\
-              "or else define boundary queries so that its unique fields may be accessed remotely."
+              "or else define resolver queries so that its unique fields may be accessed remotely."
           end
         end
       end

--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
-require_relative "./executor/boundary_source"
+require_relative "./executor/resolver_source"
 require_relative "./executor/root_source"
 
 module GraphQL
@@ -55,9 +55,9 @@ module GraphQL
           tasks = @request.plan
             .ops
             .select { next_steps.include?(_1.after) }
-            .group_by { [_1.location, _1.boundary.nil?] }
+            .group_by { [_1.location, _1.resolver.nil?] }
             .map do |(location, root_source), ops|
-              source_type = root_source ? RootSource : BoundarySource
+              source_type = root_source ? RootSource : ResolverSource
               @dataloader.with(source_type, self, location).request_all(ops)
             end
 

--- a/lib/graphql/stitching/executor/resolver_source.rb
+++ b/lib/graphql/stitching/executor/resolver_source.rb
@@ -106,7 +106,7 @@ module GraphQL::Stitching
         return unless raw_result
 
         origin_sets_by_operation.each_with_index do |(op, origin_set), batch_index|
-          results = if op.dig("resolver", "list")
+          results = if op.resolver.list?
             raw_result["_#{batch_index}_result"]
           else
             origin_set.map.with_index { |_, index| raw_result["_#{batch_index}_#{index}_result"] }

--- a/lib/graphql/stitching/plan.rb
+++ b/lib/graphql/stitching/plan.rb
@@ -14,7 +14,7 @@ module GraphQL
         :variables,
         :path,
         :if_type,
-        :boundary,
+        :resolver,
         keyword_init: true
       ) do
         def as_json
@@ -27,7 +27,7 @@ module GraphQL
             variables: variables,
             path: path,
             if_type: if_type,
-            boundary: boundary&.as_json
+            resolver: resolver&.as_json
           }.tap(&:compact!)
         end
       end
@@ -36,7 +36,7 @@ module GraphQL
         def from_json(json)
           ops = json["ops"]
           ops = ops.map do |op|
-            boundary = op["boundary"]
+            resolver = op["resolver"]
             Op.new(
               step: op["step"],
               after: op["after"],
@@ -46,7 +46,7 @@ module GraphQL
               variables: op["variables"],
               path: op["path"],
               if_type: op["if_type"],
-              boundary: boundary ? GraphQL::Stitching::Boundary.new(**boundary) : nil,
+              resolver: resolver ? GraphQL::Stitching::Resolver.new(**resolver) : nil,
             )
           end
           new(ops: ops)

--- a/lib/graphql/stitching/planner_step.rb
+++ b/lib/graphql/stitching/planner_step.rb
@@ -9,7 +9,7 @@ module GraphQL
       GRAPHQL_PRINTER = GraphQL::Language::Printer.new
 
       attr_reader :index, :location, :parent_type, :operation_type, :path
-      attr_accessor :after, :selections, :variables, :boundary
+      attr_accessor :after, :selections, :variables, :resolver
 
       def initialize(
         location:,
@@ -20,7 +20,7 @@ module GraphQL
         selections: [],
         variables: {},
         path: [],
-        boundary: nil
+        resolver: nil
       )
         @location = location
         @parent_type = parent_type
@@ -30,7 +30,7 @@ module GraphQL
         @selections = selections
         @variables = variables
         @path = path
-        @boundary = boundary
+        @resolver = resolver
       end
 
       def to_plan_op
@@ -43,17 +43,17 @@ module GraphQL
           variables: rendered_variables,
           path: @path,
           if_type: type_condition,
-          boundary: @boundary,
+          resolver: @resolver,
         )
       end
 
       private
 
-      # Concrete types going to a boundary report themselves as a type condition.
+      # Concrete types going to a resolver report themselves as a type condition.
       # This is used by the executor to evalute which planned fragment selections
       # actually apply to the resolved object types.
       def type_condition
-        @parent_type.graphql_name if @boundary && !parent_type.kind.abstract?
+        @parent_type.graphql_name if @resolver && !parent_type.kind.abstract?
       end
 
       def rendered_selections

--- a/lib/graphql/stitching/resolver.rb
+++ b/lib/graphql/stitching/resolver.rb
@@ -2,8 +2,8 @@
 
 module GraphQL
   module Stitching
-    # Defines a boundary query that provides direct access to an entity type.
-    Boundary = Struct.new(
+    # Defines a root resolver query that provides direct access to an entity type.
+    Resolver = Struct.new(
       :location,
       :type_name,
       :key,
@@ -13,6 +13,9 @@ module GraphQL
       :federation,
       keyword_init: true
     ) do
+      alias_method :list?, :list
+      alias_method :federation?, :federation
+
       def as_json
         {
           location: location,

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.2.5"
+    VERSION = "1.3.0"
   end
 end

--- a/test/graphql/stitching/composer/configuration_test.rb
+++ b/test/graphql/stitching/composer/configuration_test.rb
@@ -16,7 +16,7 @@ describe 'GraphQL::Stitching::Composer, configuration' do
     assert_equal executable, supergraph.executables["storefronts"]
   end
 
-  def test_perform_with_static_boundary_config
+  def test_perform_with_static_resolver_config
     alpha = %|
       type Product { id: ID! name: String! }
       type Query { productA(id: ID!): Product }
@@ -42,9 +42,9 @@ describe 'GraphQL::Stitching::Composer, configuration' do
       }
     })
 
-    expected_boundaries = {
+    expected_resolvers = {
       "Product" => [
-        GraphQL::Stitching::Boundary.new(
+        GraphQL::Stitching::Resolver.new(
           location: "alpha",
           type_name: "Product",
           field: "productA",
@@ -53,7 +53,7 @@ describe 'GraphQL::Stitching::Composer, configuration' do
           list: false,
           federation: false,
         ),
-        GraphQL::Stitching::Boundary.new(
+        GraphQL::Stitching::Resolver.new(
           location: "bravo",
           type_name: "Product",
           field: "productB",
@@ -65,6 +65,6 @@ describe 'GraphQL::Stitching::Composer, configuration' do
       ]
     }
 
-    assert_equal expected_boundaries, supergraph.boundaries
+    assert_equal expected_resolvers, supergraph.resolvers
   end
 end

--- a/test/graphql/stitching/composer/validate_resolvers_test.rb
+++ b/test/graphql/stitching/composer/validate_resolvers_test.rb
@@ -2,9 +2,9 @@
 
 require "test_helper"
 
-describe 'GraphQL::Stitching::Composer, validate boundaries' do
+describe 'GraphQL::Stitching::Composer, validate resolvers' do
 
-  def test_validates_only_one_boundary_query_per_type_location_key
+  def test_validates_only_one_resolver_query_per_type_location_key
     a = %{
       interface I { id:ID! }
       type T implements I { id:ID! name:String }
@@ -15,12 +15,12 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
     }
     b = %{type T { id:ID! size:Float } type Query { b:T }}
 
-    assert_error("Multiple boundary queries for `T.id` found in a", ValidationError) do
+    assert_error("Multiple resolver queries for `T.id` found in a", ValidationError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
 
-  def test_permits_multiple_boundary_query_keys_per_type_location
+  def test_permits_multiple_resolver_query_keys_per_type_location
     a = %{
       type T { upc:ID! name:String }
       type Query { a(upc:ID!):T @stitch(key: "upc") }
@@ -40,26 +40,26 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
     assert compose_definitions({ "a" => a, "b" => b, "c" => c })
   end
 
-  def test_validates_boundary_present_when_providing_unique_fields
+  def test_validates_resolver_present_when_providing_unique_fields
     a = %{type T { id:ID! name:String } type Query { a(id: ID!):T @stitch(key: "id") }}
     b = %{type T { id:ID! size:Float } type Query { b:T }}
 
-    assert_error("A boundary query is required for `T` in b", ValidationError) do
+    assert_error("A resolver query is required for `T` in b", ValidationError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
 
-  def test_validates_boundary_present_in_multiple_locations_when_providing_unique_fields
+  def test_validates_resolver_present_in_multiple_locations_when_providing_unique_fields
     a = %{type T { id:ID! name:String } type Query { a(id: ID!):T @stitch(key: "id") }}
     b = %{type T { id:ID! size:Float } type Query { b:T }}
     c = %{type T { id:ID! size:Float } type Query { c:T }}
 
-    assert_error("A boundary query is required for `T` in one of b, c locations", ValidationError) do
+    assert_error("A resolver query is required for `T` in one of b, c locations", ValidationError) do
       compose_definitions({ "a" => a, "b" => b, "c" => c })
     end
   end
 
-  def test_permits_no_boundary_query_for_types_that_can_be_fully_resolved_elsewhere
+  def test_permits_no_resolver_query_for_types_that_can_be_fully_resolved_elsewhere
     a = %{type T { id:ID! name:String } type Query { a(id: ID!):T @stitch(key: "id") }}
     b = %{type T { id:ID! size:Float } type Query { b(id: ID!):T @stitch(key: "id") }}
     c = %{type T { id:ID! size:Float name:String } type Query { c:T }}
@@ -67,7 +67,7 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
     assert compose_definitions({ "a" => a, "b" => b, "c" => c })
   end
 
-  def test_permits_no_boundary_query_for_key_only_types
+  def test_permits_no_resolver_query_for_key_only_types
     a = %{type T { id:ID! name:String } type Query { a(id: ID!):T @stitch(key: "id") }}
     b = %{type T { id:ID! } type Query { b:T }}
 
@@ -78,7 +78,7 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
     a = %{type T { id:ID! name:String } type Query { a(id: ID!):T @stitch(key: "id") }}
     b = %{type T { name:String } type Query { b:T }}
 
-    assert_error("A boundary key is required for `T` in b", ValidationError) do
+    assert_error("A resolver key is required for `T` in b", ValidationError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -97,7 +97,7 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
       type Query { c(id:ID!):T @stitch(key: "id") }
     }
 
-    assert_error("Cannot route `T` boundaries in a", ValidationError) do
+    assert_error("Cannot route `T` resolvers in a", ValidationError) do
       compose_definitions({ "a" => a, "b" => b, "c" => c })
     end
   end
@@ -116,7 +116,7 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
       type Query { c(id:ID!):T @stitch(key: "id") }
     |
 
-    assert_error("Cannot route `T` boundaries in a", ValidationError) do
+    assert_error("Cannot route `T` resolvers in a", ValidationError) do
       compose_definitions({ "a" => a, "b" => b, "c" => c })
     end
   end
@@ -135,7 +135,7 @@ describe 'GraphQL::Stitching::Composer, validate boundaries' do
       type Query { c(id:ID!):T @stitch(key: "id") }
     }
 
-    assert_error("Cannot route `T` boundaries in a", ValidationError) do
+    assert_error("Cannot route `T` resolvers in a", ValidationError) do
       compose_definitions({ "a" => a, "b" => b, "c" => c })
     end
   end

--- a/test/graphql/stitching/executor/resolver_source_test.rb
+++ b/test/graphql/stitching/executor/resolver_source_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-describe "GraphQL::Stitching::Executor, BoundarySource" do
+describe "GraphQL::Stitching::Executor, ResolverSource" do
   def setup
     @op1 = GraphQL::Stitching::Plan::Op.new(
       step: 2,
@@ -13,7 +13,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
       if_type: "Storefront",
       selections: "{ name(lang:$lang) }",
       variables: { "lang" => "String!" },
-      boundary: GraphQL::Stitching::Boundary.new(
+      resolver: GraphQL::Stitching::Resolver.new(
         location: "products",
         field: "storefronts",
         arg: "ids",
@@ -31,7 +31,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
       if_type: "Product",
       selections: "{ price(currency:$currency) }",
       variables: { "currency" => "Currency!" },
-      boundary: GraphQL::Stitching::Boundary.new(
+      resolver: GraphQL::Stitching::Resolver.new(
         location: "products",
         field: "product",
         arg: "upc",
@@ -41,7 +41,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
       )
     )
 
-    @source = GraphQL::Stitching::Executor::BoundarySource.new({}, "products")
+    @source = GraphQL::Stitching::Executor::ResolverSource.new({}, "products")
     @origin_sets_by_operation = {
       @op1 => [{ "_export_id" => "7" }, { "_export_id" => "8" }],
       @op2 => [{ "_export_upc" => "abc" }, { "_export_upc" => "xyz" }],
@@ -164,7 +164,7 @@ describe "GraphQL::Stitching::Executor, BoundarySource" do
     mock = GraphQL::Stitching::Executor.new(mock)
     mock.instance_variable_set(:@data, data)
 
-    source = GraphQL::Stitching::Executor::BoundarySource.new(mock, "products")
+    source = GraphQL::Stitching::Executor::ResolverSource.new(mock, "products")
     origin_sets_by_operation = {
       @op1 => data["storefronts"],
       @op2 => data["storefronts"].map { _1["product"] },

--- a/test/graphql/stitching/executor/root_source_test.rb
+++ b/test/graphql/stitching/executor/root_source_test.rb
@@ -13,7 +13,7 @@ describe "GraphQL::Stitching::Executor, RootSource" do
       if_type: "Storefront",
       selections: "{ storefront(id:$id) { products { _export_id: id } } }",
       variables: { "id" => "ID!" },
-      boundary: nil
+      resolver: nil
     )
 
     @source = GraphQL::Stitching::Executor::RootSource.new({}, "a")

--- a/test/graphql/stitching/integration/unions_test.rb
+++ b/test/graphql/stitching/integration/unions_test.rb
@@ -12,7 +12,7 @@ describe 'GraphQL::Stitching, unions' do
     })
   end
 
-  def test_plan_abstract_merged_via_concrete_boundaries
+  def test_plan_abstract_merged_via_concrete_resolvers
     query = %|
       {
         fruitsA(ids: ["1", "3"]) {
@@ -34,7 +34,7 @@ describe 'GraphQL::Stitching, unions' do
     assert_equal expected, result["data"]
   end
 
-  def test_plan_abstract_merged_types_via_abstract_boundary
+  def test_plan_abstract_merged_types_via_abstract_resolver
     query = %|
       {
         fruitsC(ids: ["1", "4"]) {

--- a/test/graphql/stitching/plan_test.rb
+++ b/test/graphql/stitching/plan_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 describe "GraphQL::Stitching::Plan" do
   def setup
-    @boundary = GraphQL::Stitching::Boundary.new(
+    @resolver = GraphQL::Stitching::Resolver.new(
       location: "products",
       field: "storefronts",
       arg: "ids",
@@ -22,7 +22,7 @@ describe "GraphQL::Stitching::Plan" do
       if_type: "Storefront",
       selections: "{ name(lang:$lang) }",
       variables: { "lang" => "String!" },
-      boundary: @boundary,
+      resolver: @resolver,
     )
 
     @plan = GraphQL::Stitching::Plan.new(ops: [@op])
@@ -37,7 +37,7 @@ describe "GraphQL::Stitching::Plan" do
         "variables" => {"lang" => "String!"},
         "path" => ["storefronts"],
         "if_type" => "Storefront",
-        "boundary" => {
+        "resolver" => {
           "location" => "products",
           "type_name" => "Storefront",
           "key" => "id",
@@ -56,6 +56,6 @@ describe "GraphQL::Stitching::Plan" do
   def test_from_json_deserialized_a_plan
     plan = GraphQL::Stitching::Plan.from_json(@serialized)
     assert_equal [@op], plan.ops
-    assert_equal @boundary, plan.ops.first.boundary
+    assert_equal @resolver, plan.ops.first.resolver
   end
 end

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -68,7 +68,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: squish_string(expected_root_selection),
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -77,7 +77,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ name price }",
       path: ["buyable"],
       if_type: "Product",
-      boundary: {
+      resolver: {
         field: "products",
         key: "id",
       },
@@ -179,7 +179,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       location: "a",
       selections: %|{ products(ids: ["1"]) { id name price } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
   end
 
@@ -253,7 +253,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       location: "a",
       selections: squish_string(expected_root_selection),
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -262,7 +262,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ b }",
       path: ["fruit"],
       if_type: "Apple",
-      boundary: {
+      resolver: {
         location: "b",
         key: "id",
       },
@@ -274,7 +274,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ c }",
       path: ["fruit"],
       if_type: "Apple",
-      boundary: {
+      resolver: {
         location: "c",
         key: "id",
       },
@@ -286,7 +286,7 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ b }",
       path: ["fruit"],
       if_type: "Banana",
-      boundary: {
+      resolver: {
         location: "b",
         key: "id",
       },

--- a/test/graphql/stitching/planner/plan_resolvers_test.rb
+++ b/test/graphql/stitching/planner/plan_resolvers_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-describe "GraphQL::Stitching::Planner, boundaries" do
+describe "GraphQL::Stitching::Planner, resolvers" do
   def build_sample_graph
     @storefronts_sdl = %|
       type Storefront {
@@ -54,7 +54,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
     })
   end
 
-  def test_collects_unique_fields_across_boundary_locations
+  def test_collects_unique_fields_across_resolver_locations
     document = %|
       query {
         storefront(id: "1") {
@@ -82,7 +82,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ storefront(id: "1") { name products { _export_upc: upc _export___typename: __typename } } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -91,7 +91,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ name manufacturer { products { name } _export_id: id _export___typename: __typename } }|,
       path: ["storefront", "products"],
-      boundary: {
+      resolver: {
         field: "product",
         key: "upc",
       },
@@ -103,7 +103,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ address }|,
       path: ["storefront", "products", "manufacturer"],
-      boundary: {
+      resolver: {
         field: "manufacturer",
         key: "id",
       },
@@ -127,7 +127,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ manufacturer(id: "1") { name _export_id: id _export___typename: __typename } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan1.ops[1].as_json, {
@@ -136,7 +136,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ products { name } }|,
       path: ["manufacturer"],
-      boundary: {
+      resolver: {
         field: "productsManufacturer",
         key: "id",
       },
@@ -148,7 +148,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ productsManufacturer(id: "1") { name products { name } } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
   end
 
@@ -180,7 +180,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ apple(id: "1") { id name _export_id: id _export___typename: __typename } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -189,7 +189,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ ... on Apple { weight } }|,
       path: ["apple"],
-      boundary: {
+      resolver: {
         field: "node",
         key: "id",
       },
@@ -224,7 +224,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ apple(id: "1") { id name _export_id: id _export___typename: __typename } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -233,7 +233,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ ... on Apple { weight } }|,
       path: ["apple"],
-      boundary: {
+      resolver: {
         field: "node",
         key: "id",
       },
@@ -269,7 +269,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ node(id: "1") { id ... on Apple { name _export_id: id _export___typename: __typename } _export___typename: __typename } }|,
       path: [],
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -278,7 +278,7 @@ describe "GraphQL::Stitching::Planner, boundaries" do
       operation_type: "query",
       selections: %|{ ... on Apple { weight } }|,
       path: ["node"],
-      boundary: {
+      resolver: {
         field: "fruit",
         key: "id",
       },

--- a/test/graphql/stitching/planner/plan_root_operations_test.rb
+++ b/test/graphql/stitching/planner/plan_root_operations_test.rb
@@ -44,7 +44,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       selections: %|{ a: widget { id } c: widget { id } }|,
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -54,7 +54,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       selections: %|{ b: sprocket { id } d: sprocket { id } }|,
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
   end
 
@@ -80,7 +80,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       selections: %|{ a: makeWidget { id } }|,
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[1].as_json, {
@@ -90,7 +90,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       selections: %|{ b: makeSprocket { id } c: makeSprocket { id } }|,
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
 
     assert_keys plan.ops[2].as_json, {
@@ -100,7 +100,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       selections: %|{ d: makeWidget { id } e: makeWidget { id } }|,
       path: [],
       if_type: nil,
-      boundary: nil,
+      resolver: nil,
     }
   end
 

--- a/test/graphql/stitching/supergraph_test.rb
+++ b/test/graphql/stitching/supergraph_test.rb
@@ -82,9 +82,9 @@ describe "GraphQL::Stitching::Supergraph" do
     },
   }
 
-  BOUNDARIES_MAP = {
+  RESOLVERS_MAP = {
     "Manufacturer" => [
-      GraphQL::Stitching::Boundary.new(
+      GraphQL::Stitching::Resolver.new(
         location: "manufacturers",
         field: "manufacturer",
         arg: "id",
@@ -92,7 +92,7 @@ describe "GraphQL::Stitching::Supergraph" do
       ),
     ],
     "Product" => [
-      GraphQL::Stitching::Boundary.new(
+      GraphQL::Stitching::Resolver.new(
         location: "products",
         field: "products",
         arg: "upc",
@@ -100,7 +100,7 @@ describe "GraphQL::Stitching::Supergraph" do
       ),
     ],
     "Storefront" => [
-      GraphQL::Stitching::Boundary.new(
+      GraphQL::Stitching::Resolver.new(
         location: "storefronts",
         field: "storefronts",
         arg: "id",
@@ -113,7 +113,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
     )
 
     mapping = supergraph.fields_by_type_and_location
@@ -126,7 +126,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
     )
 
     mapping = supergraph.locations_by_type
@@ -139,7 +139,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
     )
 
     assert_equal ["upc"], supergraph.possible_keys_for_type_and_location("Product", "products")
@@ -151,7 +151,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
     )
 
     ["__Schema", "__Type", "__Field"].each do |introspection_type|
@@ -168,7 +168,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
       executables: {
         "products" => executable1,
         "storefronts" => executable2,
@@ -190,7 +190,7 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = GraphQL::Stitching::Supergraph.new(
       schema: ComposedSchema,
       fields: FIELDS_MAP.dup,
-      boundaries: BOUNDARIES_MAP,
+      resolvers: RESOLVERS_MAP,
       executables: {
         products: executable1,
         storefronts: executable2,
@@ -209,7 +209,7 @@ describe "GraphQL::Stitching::Supergraph" do
       GraphQL::Stitching::Supergraph.new(
         schema: ComposedSchema,
         fields: FIELDS_MAP.dup,
-        boundaries: BOUNDARIES_MAP,
+        resolvers: RESOLVERS_MAP,
         executables: {
           products: "nope",
         },
@@ -341,10 +341,10 @@ describe "GraphQL::Stitching::Supergraph" do
       })
 
       assert_equal @supergraph.fields, supergraph_import.fields
-      assert_equal @supergraph.boundaries, supergraph_import.boundaries
+      assert_equal @supergraph.resolvers, supergraph_import.resolvers
       assert_equal ["alpha", "bravo"], supergraph_import.locations.sort
       assert_equal @supergraph.schema.types.keys.sort, supergraph_import.schema.types.keys.sort
-      assert_equal @supergraph.boundaries, supergraph_import.boundaries
+      assert_equal @supergraph.resolvers, supergraph_import.resolvers
     end
 
     def test_normalizes_executable_location_names

--- a/test/schemas/conditionals.rb
+++ b/test/schemas/conditionals.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Conditionals
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -22,7 +22,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :apple_extension, AppleExtension, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -42,7 +42,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :banana_extension, BananaExtension, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 

--- a/test/schemas/errors.rb
+++ b/test/schemas/errors.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Errors
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -43,7 +43,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :elements_a, [Element, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 
@@ -62,7 +62,7 @@ module Schemas
         end
 
         field :isotope_a, Isotope, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -88,7 +88,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :elements_b, [Element, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 
@@ -99,7 +99,7 @@ module Schemas
         end
 
         field :isotope_b, Isotope, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 

--- a/test/schemas/example.rb
+++ b/test/schemas/example.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Example
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -56,7 +56,7 @@ module Schemas
 
       class RootQuery < GraphQL::Schema::Object
         field :product, Product, null: false do
-          directive Boundary, key: "upc"
+          directive Resolver, key: "upc"
           argument :upc, ID, required: true
         end
 
@@ -65,7 +65,7 @@ module Schemas
         end
 
         field :manufacturer, Manufacturer, null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -122,7 +122,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :manufacturer, Manufacturer, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 

--- a/test/schemas/interfaces.rb
+++ b/test/schemas/interfaces.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Interfaces
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -66,7 +66,7 @@ module Schemas
         end
 
         field :products_buyables, [Buyable, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 
@@ -75,7 +75,7 @@ module Schemas
         end
 
         field :products_split, [Split, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 
@@ -149,7 +149,7 @@ module Schemas
         end
 
         field :bundles_buyables, [Buyable, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 
@@ -158,7 +158,7 @@ module Schemas
         end
 
         field :bundles_split, [Split, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 

--- a/test/schemas/multiple_keys.rb
+++ b/test/schemas/multiple_keys.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module MultipleKeys
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -23,7 +23,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :storefronts_product_by_id, Product, null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -46,7 +46,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :products_product_by_id, Product, null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -55,7 +55,7 @@ module Schemas
         end
 
         field :products_product_by_upc, Product, null: false do
-          directive Boundary, key: "upc"
+          directive Resolver, key: "upc"
           argument :upc, ID, required: true
         end
 
@@ -77,7 +77,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :catalogs_product_by_upc, Product, null: false do
-          directive Boundary, key: "upc"
+          directive Resolver, key: "upc"
           argument :upc, ID, required: true
         end
 

--- a/test/schemas/mutations.rb
+++ b/test/schemas/mutations.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Mutations
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -34,7 +34,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :recordA, Record, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -68,7 +68,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :recordB, Record, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 

--- a/test/schemas/shareables.rb
+++ b/test/schemas/shareables.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Shareables
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -31,7 +31,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :gadget_a, Gadget, null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -65,7 +65,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :gadget_b, Gadget, null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 

--- a/test/schemas/unions.rb
+++ b/test/schemas/unions.rb
@@ -2,7 +2,7 @@
 
 module Schemas
   module Unions
-    class Boundary < GraphQL::Schema::Directive
+    class Resolver < GraphQL::Schema::Directive
       graphql_name "stitch"
       locations FIELD_DEFINITION
       argument :key, String
@@ -49,7 +49,7 @@ module Schemas
         end
 
         field :apple_a, Apple, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -58,7 +58,7 @@ module Schemas
         end
 
         field :banana_b, Banana, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -97,7 +97,7 @@ module Schemas
 
       class Query < GraphQL::Schema::Object
         field :apple_b, Apple, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -106,7 +106,7 @@ module Schemas
         end
 
         field :banana_b, Banana, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -115,7 +115,7 @@ module Schemas
         end
 
         field :coconut_b, Coconut, null: true do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :id, ID, required: true
         end
 
@@ -152,7 +152,7 @@ module Schemas
         end
 
         field :fruits_c, [Fruit, null: true], null: false do
-          directive Boundary, key: "id"
+          directive Resolver, key: "id"
           argument :ids, [ID], required: true
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,11 +49,11 @@ def compose_definitions(locations, options={})
   GraphQL::Stitching::Composer.new(**options).perform(locations)
 end
 
-def supergraph_from_schema(schema, fields: {}, boundaries: {}, executables: {})
+def supergraph_from_schema(schema, fields: {}, resolvers: {}, executables: {})
   GraphQL::Stitching::Supergraph.new(
     schema: schema.is_a?(String) ? GraphQL::Schema.from_definition(schema) : schema,
     fields: fields,
-    boundaries: boundaries,
+    resolvers: resolvers,
     executables: executables,
   )
 end


### PR DESCRIPTION
This is a 1:1 rename of all mentions of the term `Boundary` into `Resolver`. Docs have already steered this nomenclature, so the matching code refactor is overdue. 

This is a pretty benign change that mostly only affects private APIs. The only affected public API should be `Supergraph.boundaries`, which is now `Supergraph.resolvers`.