### PR TITLE
Versioned resolvers

### DIFF
--- a/lib/graphql/stitching/client.rb
+++ b/lib/graphql/stitching/client.rb
@@ -70,7 +70,11 @@ module GraphQL
       def load_plan(request)
         if @on_cache_read && plan_json = @on_cache_read.call(request)
           plan = GraphQL::Stitching::Plan.from_json(JSON.parse(plan_json))
-          return request.plan(plan)
+
+          # only use plans referencing current resolver versions
+          if plan.ops.all? { |op| !op.resolver || @supergraph.resolvers_by_version[op.resolver] }
+            return request.plan(plan)
+          end
         end
 
         plan = request.plan

--- a/lib/graphql/stitching/executor/resolver_source.rb
+++ b/lib/graphql/stitching/executor/resolver_source.rb
@@ -53,7 +53,7 @@ module GraphQL::Stitching
         variable_defs = {}
         query_fields = origin_sets_by_operation.map.with_index do |(op, origin_set), batch_index|
           variable_defs.merge!(op.variables)
-          resolver = op.resolver
+          resolver = @executor.request.supergraph.resolvers_by_version[op.resolver]
 
           if resolver.list?
             variable_name = "_#{batch_index}_key"
@@ -115,7 +115,7 @@ module GraphQL::Stitching
         return unless raw_result
 
         origin_sets_by_operation.each_with_index do |(op, origin_set), batch_index|
-          results = if op.resolver.list?
+          results = if @executor.request.supergraph.resolvers_by_version[op.resolver].list?
             raw_result["_#{batch_index}_result"]
           else
             origin_set.map.with_index { |_, index| raw_result["_#{batch_index}_#{index}_result"] }

--- a/lib/graphql/stitching/plan.rb
+++ b/lib/graphql/stitching/plan.rb
@@ -27,7 +27,7 @@ module GraphQL
             variables: variables,
             path: path,
             if_type: if_type,
-            resolver: resolver&.as_json
+            resolver: resolver
           }.tap(&:compact!)
         end
       end
@@ -36,7 +36,6 @@ module GraphQL
         def from_json(json)
           ops = json["ops"]
           ops = ops.map do |op|
-            resolver = op["resolver"]
             Op.new(
               step: op["step"],
               after: op["after"],
@@ -46,7 +45,7 @@ module GraphQL
               variables: op["variables"],
               path: op["path"],
               if_type: op["if_type"],
-              resolver: resolver ? GraphQL::Stitching::Resolver.new(**resolver) : nil,
+              resolver: op["resolver"],
             )
           end
           new(ops: ops)

--- a/lib/graphql/stitching/planner_step.rb
+++ b/lib/graphql/stitching/planner_step.rb
@@ -43,7 +43,7 @@ module GraphQL
           variables: rendered_variables,
           path: @path,
           if_type: type_condition,
-          resolver: @resolver,
+          resolver: @resolver&.version,
         )
       end
 

--- a/lib/graphql/stitching/resolver.rb
+++ b/lib/graphql/stitching/resolver.rb
@@ -32,6 +32,10 @@ module GraphQL
       alias_method :list?, :list
       alias_method :representations?, :representations
 
+      def version
+        @version ||= Digest::SHA2.hexdigest(as_json.to_json)
+      end
+
       def as_json
         {
           location: location,

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -86,6 +86,7 @@ module GraphQL
         @schema.use(GraphQL::Schema::AlwaysVisible)
 
         @resolvers = resolvers
+        @resolvers_by_version = nil
         @fields_by_type_and_location = nil
         @locations_by_type = nil
         @memoized_introspection_types = nil
@@ -170,6 +171,12 @@ module GraphQL
       # @return [GraphQL::StaticValidation::Validator] static validator for the supergraph schema.
       def static_validator
         @static_validator ||= @schema.static_validator
+      end
+
+      def resolvers_by_version
+        @resolvers_by_version ||= resolvers.values.tap(&:flatten!).each_with_object({}) do |resolver, memo|
+          memo[resolver.version] = resolver
+        end
       end
 
       def fields

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
   end
 end

--- a/test/graphql/stitching/plan_test.rb
+++ b/test/graphql/stitching/plan_test.rb
@@ -22,7 +22,7 @@ describe "GraphQL::Stitching::Plan" do
       if_type: "Storefront",
       selections: "{ name(lang:$lang) }",
       variables: { "lang" => "String!" },
-      resolver: @resolver,
+      resolver: @resolver.version,
     )
 
     @plan = GraphQL::Stitching::Plan.new(ops: [@op])
@@ -37,14 +37,7 @@ describe "GraphQL::Stitching::Plan" do
         "variables" => {"lang" => "String!"},
         "path" => ["storefronts"],
         "if_type" => "Storefront",
-        "resolver" => {
-          "location" => "products",
-          "type_name" => "Storefront",
-          "key" => "id",
-          "field" => "storefronts",
-          "arg" => "ids",
-          "list" => true,
-        },
+        "resolver" => @resolver.version,
       }],
     }
   end
@@ -56,6 +49,6 @@ describe "GraphQL::Stitching::Plan" do
   def test_from_json_deserialized_a_plan
     plan = GraphQL::Stitching::Plan.from_json(@serialized)
     assert_equal [@op], plan.ops
-    assert_equal @resolver, plan.ops.first.resolver
+    assert_equal @resolver.version, plan.ops.first.resolver
   end
 end

--- a/test/graphql/stitching/planner/plan_abstracts_test.rb
+++ b/test/graphql/stitching/planner/plan_abstracts_test.rb
@@ -77,10 +77,11 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ name price }",
       path: ["buyable"],
       if_type: "Product",
-      resolver: {
+      resolver: resolver_version("Product", {
+        location: "a",
         field: "products",
         key: "id",
-      },
+      }),
     }
   end
 
@@ -262,10 +263,10 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ b }",
       path: ["fruit"],
       if_type: "Apple",
-      resolver: {
+      resolver: resolver_version("Apple", {
         location: "b",
         key: "id",
-      },
+      }),
     }
 
     assert_keys plan.ops[2].as_json, {
@@ -274,10 +275,10 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ c }",
       path: ["fruit"],
       if_type: "Apple",
-      resolver: {
+      resolver: resolver_version("Apple", {
         location: "c",
         key: "id",
-      },
+      }),
     }
 
     assert_keys plan.ops[3].as_json, {
@@ -286,10 +287,19 @@ describe "GraphQL::Stitching::Planner, abstract merged types" do
       selections: "{ b }",
       path: ["fruit"],
       if_type: "Banana",
-      resolver: {
+      resolver: resolver_version("Banana", {
         location: "b",
         key: "id",
-      },
+      }),
     }
+  end
+
+  private
+
+  def resolver_version(type_name, criteria)
+    @supergraph.resolvers[type_name].find do |resolver|
+      json = resolver.as_json
+      criteria.all? { |k, v| json[k] == v }
+    end.version
   end
 end


### PR DESCRIPTION
We'd like to simplify plans by removing resolver information from them. This becomes increasingly important as resolvers potentially get bigger and more involved. So, rather than embedding full resolvers into a plan, we'll just insert resolver version hashes to pull from the supergraph.

As an added benefit, this also invalidates stale cached plans caused by resolver changes.