### PR TITLE
Argument shapes

### DIFF
--- a/docs/resolver.md
+++ b/docs/resolver.md
@@ -1,0 +1,101 @@
+## GraphQL::Stitching::Resolver
+
+A `Resolver` contains all information about a root query used by stitching to fetch location-specific variants of a merged type. Specifically, resolvers manage parsed keys and argument structures.
+
+### Arguments
+
+Resolvers configure arguments through a template string of [GraphQL argument literal syntax](https://spec.graphql.org/October2021/#sec-Language.Arguments). This allows sending multiple arguments that intermix stitching keys with complex object shapes and other static values.
+
+#### Key insertions
+
+Key values are selections read from the original record that was fetched from previous locations. This origin record is represented by `$`, and dot-notation paths may reference key fields from it. At present, only two key fields are supported: the `key` named by the resolver, and `__typename`.
+
+```graphql
+type Query {
+  entity(id: ID!, type: String!): [Entity]!
+    @stitch(key: "id", arguments: "id: $.id, type: $.__typename")
+}
+```
+
+Key insertions are _not_ quoted to differentiate them from other literal values.
+
+#### Lists
+
+List arguments may specify input just like non-list arguments, and [GraphQL list input coercion](https://spec.graphql.org/October2021/#sec-List.Input-Coercion) will assume the shape represents a list item:
+
+```graphql
+type Query {
+  product(ids: [ID!]!, source: DataSource!): [Product]!
+    @stitch(key: "id", arguments: "ids: $.id, source: CACHE")
+}
+```
+
+List resolvers (that return list types) may _only_ insert keys into repeatable list arguments, while non-list arguments may only contain static values. Nested list inputs are neither common nor practical, so are not supported.
+
+#### Built-in scalars
+
+Built-in scalars are written as normal literal values. For convenience, string literals may be enclosed in single quotes rather than escaped double-quotes:
+
+```graphql
+type Query {
+  product(id: ID!, source: String!): Product
+    @stitch(key: "id", arguments: "id: $.id, source: 'cache'")
+
+  variant(id: ID!, limit: Int!): Variant
+    @stitch(key: "id", arguments: "id: $.id, limit: 100")
+}
+```
+
+All scalar usage must be legal to the resolver field's arguments schema.
+
+#### Enums
+
+Enum literals may be provided anywhere in the input structure. They are _not_ quoted:
+
+```graphql
+enum DataSource {
+  CACHE
+}
+type Query {
+  product(id: ID!, source: DataSource!): [Product]!
+    @stitch(key: "id", arguments: "id: $.id, source: CACHE")
+}
+```
+
+All enum usage must be legal to the resolver field's arguments schema.
+
+#### Input Objects
+
+Input objects may be provided anywhere in the input, even as nested structures. The stitching resolver will build the specified object shape:
+
+```graphql
+input ComplexKey {
+  id: ID
+  nested: ComplexKey
+}
+type Query {
+  product(key: ComplexKey!): [Product]!
+    @stitch(key: "id", arguments: "key: { nested: { id: $.id } }")
+}
+```
+
+Input object shapes must conform to their respective schema definitions based on their placement within resolver arguments.
+
+#### Custom scalars
+
+Custom scalar keys allow any input shape to be submitted, from primitive scalars to complex object structures. These values will be sent and recieved as untyped JSON input:
+
+```graphql
+type Product {
+  id: ID!
+}
+union Entity = Product
+scalar Key
+
+type Query {
+  entities(representations: [Key!]!): [Entity]!
+    @stitch(key: "id", arguments: "representations: { id: $.id, __typename: $.__typename }")
+}
+```
+
+Custom scalar arguments have no structured schema definition to validate against. This makes them flexible but quite lax, for better or worse.

--- a/lib/graphql/stitching/resolver.rb
+++ b/lib/graphql/stitching/resolver.rb
@@ -1,51 +1,66 @@
 # frozen_string_literal: true
 
+require_relative "./resolver/arguments"
+
 module GraphQL
   module Stitching
     # Defines a root resolver query that provides direct access to an entity type.
-    Resolver = Struct.new(
+    class Resolver
+      extend ArgumentsParser
+
       # location name providing the resolver query.
-      :location,
+      attr_reader :location
 
       # name of merged type fulfilled through this resolver.
-      :type_name,
-
-      # a key field to select from prior locations, sent as resolver argument.
-      :key,
+      attr_reader :type_name
 
       # name of the root field to query.
-      :field,
+      attr_reader :field
+
+      # a key field to select from prior locations, sent as resolver argument.
+      attr_reader :key
+
+      # parsed resolver Argument structures.
+      attr_reader :arguments
+
+      def initialize(
+        location:,
+        type_name: nil,
+        list: false,
+        field: nil,
+        key: nil,
+        arguments: nil
+      )
+        @location = location
+        @type_name = type_name
+        @list = list
+        @field = field
+        @key = key
+        @arguments = arguments
+      end
 
       # specifies when the resolver is a list query.
-      :list,
-
-      # name of the root field argument used to send the key.
-      :arg,
-
-      # type name of the root field argument used to send the key.
-      :arg_type_name,
-
-      # specifies that keys should be sent as JSON representations with __typename and key.
-      :representations,
-      keyword_init: true
-    ) do
-      alias_method :list?, :list
-      alias_method :representations?, :representations
+      def list?
+        @list
+      end
 
       def version
         @version ||= Digest::SHA2.hexdigest(as_json.to_json)
+      end
+
+      def ==(other)
+        self.class == other.class && self.as_json == other.as_json
       end
 
       def as_json
         {
           location: location,
           type_name: type_name,
-          key: key,
+          list: list?,
           field: field,
-          list: list,
-          arg: arg,
-          arg_type_name: arg_type_name,
-          representations: representations,
+          key: key,
+          arguments: arguments.map(&:to_definition).join(", "),
+          argument_types: arguments.map(&:to_type_definition).join(", "),
         }.tap(&:compact!)
       end
     end

--- a/lib/graphql/stitching/resolver/arguments.rb
+++ b/lib/graphql/stitching/resolver/arguments.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+module GraphQL::Stitching
+  class Resolver
+    # Defines a single resolver argument structure
+    # @api private
+    class Argument
+      attr_reader :name
+      attr_reader :value
+      attr_reader :type_name
+
+      def initialize(name:, value:, list: false, type_name: nil)
+        @name = name
+        @value = value
+        @list = list
+        @type_name = type_name
+      end
+
+      def list?
+        @list
+      end
+
+      def key?
+        value.key?
+      end
+
+      def ==(other)
+        self.class == other.class &&
+          @name == other.name &&
+          @value == other.value &&
+          @type_name == other.type_name &&
+          @list == other.list?
+      end
+
+      def build(origin_obj)
+        value.build(origin_obj)
+      end
+
+      def print
+        "#{name}: #{value.print}"
+      end
+
+      def to_definition
+        print.gsub(%|"|, "'")
+      end
+
+      def to_type_definition
+        "#{name}: #{to_type_signature}"
+      end
+
+      def to_type_signature
+        # need to derive nullability...
+        list? ? "[#{@type_name}!]!" : "#{@type_name}!"
+      end
+    end
+
+    # An abstract argument input value
+    # @api private
+    class ArgumentValue
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def key?
+        false
+      end
+
+      def ==(other)
+        self.class == other.class && value == other.value
+      end
+
+      def build(origin_obj)
+        value
+      end
+
+      def print
+        value
+      end
+    end
+
+    # An object input value
+    # @api private
+    class ObjectValue < ArgumentValue
+      def key?
+        value.any?(&:key?)
+      end
+
+      def build(origin_obj)
+        value.each_with_object({}) do |arg, memo|
+          memo[arg.name] = arg.build(origin_obj)
+        end
+      end
+
+      def print
+        "{#{value.map(&:print).join(", ")}}"
+      end
+    end
+
+    # A key input value
+    # @api private
+    class KeyValue < ArgumentValue
+      def initialize(value)
+        super(Array(value))
+      end
+
+      def key?
+        true
+      end
+
+      def build(origin_obj)
+        value.reduce(origin_obj) { |obj, ns| obj[ExportSelection.key(ns)] }
+      end
+
+      def print
+        "$.#{value.join(".")}"
+      end
+    end
+
+    # A typed enum input value
+    # @api private
+    class EnumValue < ArgumentValue
+    end
+
+    # A primitive input value literal
+    # @api private
+    class LiteralValue < ArgumentValue
+      def print
+        JSON.generate(value)
+      end
+    end
+
+    # Parser for building argument templates into resolver structures
+    # @api private
+    module ArgumentsParser
+      # Parses an argument template string into resolver arguments via schema casting.
+      # @param template [String] the template string to parse.
+      # @param field_def [GraphQL::Schema::FieldDefinition] a field definition providing arguments schema.
+      # @return [[GraphQL::Stitching::Resolver::Argument]] an array of resolver arguments.
+      def parse_arguments(template, field_def)
+        ast = parse_arg_defs(template)
+        build_argument_set(ast, field_def.arguments, repeatable_key: field_def.type.list?)
+      end
+
+      # Parses an argument template string into resolver arguments via SDL casting.
+      # @param template [String] the template string to parse.
+      # @param type_defs [String] the type definition string declaring argument types.
+      # @return [[GraphQL::Stitching::Resolver::Argument]] an array of resolver arguments.
+      def parse_arguments_with_type_defs(template, type_defs)
+        type_map = parse_type_defs(type_defs)
+        parse_arg_defs(template).map { build_argument(_1, nil, type_struct: type_map[_1.name]) }
+      end
+
+      private
+
+      def parse_arg_defs(template)
+        template = template.gsub("'", %|"|).gsub(/(\$[\w\.]+)/) { %|"#{_1}"| }
+        if template.start_with?("(")
+          template = template[1..-1]
+          template = template[0..-2] if template.end_with?(")")
+        end
+
+        GraphQL.parse("{ f(#{template}) }")
+          .definitions.first
+          .selections.first
+          .arguments
+      end
+
+      def parse_type_defs(template)
+        GraphQL.parse("type T { #{template} }")
+          .definitions.first
+          .fields.each_with_object({}) do |node, memo|
+            memo[node.name] = GraphQL::Stitching::Util.flatten_ast_type_structure(node.type)
+          end
+      end
+
+      def build_argument_set(nodes, argument_defs, static_scope: false, repeatable_key: false)
+        if argument_defs
+          argument_defs.each_value do |argument_def|
+            if argument_def.type.non_null? && !nodes.find { _1.name == argument_def.graphql_name }
+              raise "Required argument `#{argument_def.graphql_name}` has no input."
+            end
+          end
+        end
+
+        nodes.map do |n|
+          argument_def = if argument_defs
+            unless d = argument_defs[n.name]
+              raise "Input `#{n.name}` is not a valid argument."
+            end
+
+            # lock the use of keys in a root argument's subtree
+            # when the key is repeatable (list fields) but the argument is not.
+            static_scope = true if repeatable_key && !d.type.list?
+            d
+          end
+
+          build_argument(n, argument_def, static_scope:)
+        end
+      end
+
+      def build_argument(node, argument_def, static_scope: false, type_struct: nil)
+        value = if node.value.is_a?(GraphQL::Language::Nodes::InputObject)
+          object_def = argument_def ? argument_def.type.unwrap : nil
+          build_object_value(node.value, object_def, static_scope:)
+        elsif node.value.is_a?(GraphQL::Language::Nodes::Enum)
+          EnumValue.new(node.value.name)
+        elsif node.value.is_a?(String) && node.value.start_with?("$.")
+          if static_scope
+            raise "Cannot use repeatable key `#{node.value}` in non-list argument `#{argument_def&.graphql_name}`."
+          end
+          KeyValue.new(node.value.sub(/^\$\./, "").split("."))
+        else
+          LiteralValue.new(node.value)
+        end
+
+        Argument.new(
+          name: node.name,
+          value: value,
+          # doesn't support nested lists...?
+          list: argument_def ? argument_def.type.list? : (type_struct&.first&.list? || false),
+          type_name: argument_def ? argument_def.type.unwrap.graphql_name : type_struct&.last&.name,
+        )
+      end
+
+      def build_object_value(node, object_def, static_scope: false)
+        if object_def
+          if !object_def.kind.input_object? && !object_def.kind.scalar?
+            raise "Objects can only be built into input object and scalar positions."
+          elsif object_def.kind.scalar? && GraphQL::Schema::BUILT_IN_TYPES[object_def.graphql_name]
+            raise "Objects can only be built into custom scalar types."
+          elsif object_def.kind.scalar?
+            object_def = nil
+          end
+        end
+
+        ObjectValue.new(build_argument_set(node.arguments, object_def&.arguments, static_scope:))
+      end
+    end
+  end
+end

--- a/lib/graphql/stitching/supergraph/resolver_directive.rb
+++ b/lib/graphql/stitching/supergraph/resolver_directive.rb
@@ -5,14 +5,13 @@ module GraphQL::Stitching
     class ResolverDirective < GraphQL::Schema::Directive
       graphql_name "resolver"
       locations OBJECT, INTERFACE, UNION
-      argument :type_name, String, required: false
       argument :location, String, required: true
+      argument :list, Boolean, required: false
       argument :key, String, required: true
       argument :field, String, required: true
-      argument :arg, String, required: true
-      argument :arg_type_name, String, required: true
-      argument :list, Boolean, required: false
-      argument :representations, Boolean, required: false
+      argument :arguments, String, required: true
+      argument :argument_types, String, required: true
+      argument :type_name, String, required: false
       repeatable true
     end
   end

--- a/lib/graphql/stitching/util.rb
+++ b/lib/graphql/stitching/util.rb
@@ -47,6 +47,34 @@ module GraphQL
           structure
         end
 
+        # builds a single-dimensional representation of a wrapped type structure from AST
+        def flatten_ast_type_structure(ast, structure: [])
+          null = true
+
+          while ast.is_a?(GraphQL::Language::Nodes::NonNullType)
+            ast = ast.of_type
+            null = false
+          end
+
+          if ast.is_a?(GraphQL::Language::Nodes::ListType)
+            structure << TypeStructure.new(
+              list: true,
+              null: null,
+              name: nil,
+            )
+
+            flatten_ast_type_structure(ast.of_type, structure:)
+          else
+            structure << TypeStructure.new(
+              list: false,
+              null: null,
+              name: ast.name,
+            )
+          end
+
+          structure
+        end
+
         # expands interfaces and unions to an array of their memberships
         # like `schema.possible_types`, but includes child interfaces
         def expand_abstract_type(schema, parent_type)

--- a/test/graphql/stitching/composer/configuration_test.rb
+++ b/test/graphql/stitching/composer/configuration_test.rb
@@ -37,7 +37,7 @@ describe 'GraphQL::Stitching::Composer, configuration' do
       bravo: {
         schema: GraphQL::Schema.from_definition(bravo),
         stitch: [
-          { field_name: "productB", key: "key:id" },
+          { field_name: "productB", key: "id", arguments: "key: $.id" },
         ]
       }
     })
@@ -47,22 +47,18 @@ describe 'GraphQL::Stitching::Composer, configuration' do
         GraphQL::Stitching::Resolver.new(
           location: "alpha",
           type_name: "Product",
+          list: false,
           field: "productA",
           key: "id",
-          arg: "id",
-          arg_type_name: "ID",
-          list: false,
-          representations: false,
+          arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("id: $.id", "id: ID"),
         ),
         GraphQL::Stitching::Resolver.new(
           location: "bravo",
           type_name: "Product",
+          list: false,
           field: "productB",
           key: "id",
-          arg: "key",
-          arg_type_name: "ID",
-          list: false,
-          representations: false,
+          arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("key: $.id", "key: ID"),
         ),
       ]
     }

--- a/test/graphql/stitching/executor/executor_test.rb
+++ b/test/graphql/stitching/executor/executor_test.rb
@@ -50,18 +50,18 @@ describe "GraphQL::Stitching::Executor" do
       query{ featured { _export_id: id _export___typename: __typename } }
     |
     expected_source2 = %|
-      query($_0_0_key:ID!,$_0_1_key:ID!,$_0_2_key:ID!){
-        _0_0_result: product(id:$_0_0_key) { name }
-        _0_1_result: product(id:$_0_1_key) { name }
-        _0_2_result: product(id:$_0_2_key) { name }
+      query($_0_0_key_0:ID!,$_0_1_key_0:ID!,$_0_2_key_0:ID!){
+        _0_0_result: product(id:$_0_0_key_0) { name }
+        _0_1_result: product(id:$_0_1_key_0) { name }
+        _0_2_result: product(id:$_0_2_key_0) { name }
       }
     |
 
     expected_vars1 = {}
     expected_vars2 = {
-      "_0_0_key" => "1",
-      "_0_1_key" => "2",
-      "_0_2_key" => "3",
+      "_0_0_key_0" => "1",
+      "_0_1_key_0" => "2",
+      "_0_2_key_0" => "3",
     }
 
     execs = mock_execs(req, [
@@ -97,12 +97,12 @@ describe "GraphQL::Stitching::Executor" do
       query Test_1 @inContext(lang: "EN") { featured { _export_id: id _export___typename: __typename } }
     |
     expected_source2 = %|
-      query Test_2($_0_0_key:ID!) @inContext(lang: "EN") { _0_0_result: product(id:$_0_0_key) { name } }
+      query Test_2($_0_0_key_0:ID!) @inContext(lang: "EN") { _0_0_result: product(id:$_0_0_key_0) { name } }
     |
 
     expected_vars1 = {}
     expected_vars2 = {
-      "_0_0_key" => "1",
+      "_0_0_key_0" => "1",
     }
 
     execs = mock_execs(req, [

--- a/test/graphql/stitching/executor/resolver_source_test.rb
+++ b/test/graphql/stitching/executor/resolver_source_test.rb
@@ -6,21 +6,19 @@ describe "GraphQL::Stitching::Executor, ResolverSource" do
   def setup
     @resolver1 = GraphQL::Stitching::Resolver.new(
       location: "products",
-      field: "storefronts",
-      arg: "ids",
-      arg_type_name: "ID",
-      key: "id",
+      type_name: "Storefront",
       list: true,
-      type_name: "Storefront"
+      field: "storefronts",
+      key: "id",
+      arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("ids: $.id", "ids: [ID]"),
     )
     @resolver2 = GraphQL::Stitching::Resolver.new(
       location: "products",
-      field: "product",
-      arg: "upc",
-      arg_type_name: "ID",
-      key: "upc",
+      type_name: "Product",
       list: false,
-      type_name: "Product"
+      field: "product",
+      key: "upc",
+      arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("upc: $.upc", "upc: ID"),
     )
 
     @op1 = GraphQL::Stitching::Plan::Op.new(
@@ -63,10 +61,10 @@ describe "GraphQL::Stitching::Executor, ResolverSource" do
     query_document, variable_names = @source.build_document(@origin_sets_by_operation)
 
     expected = %|
-      query($lang:String!,$_0_key:[ID!]!,$currency:Currency!,$_1_0_key:ID!,$_1_1_key:ID!){
-        _0_result: storefronts(ids:$_0_key) { name(lang:$lang) }
-        _1_0_result: product(upc:$_1_0_key) { price(currency:$currency) }
-        _1_1_result: product(upc:$_1_1_key) { price(currency:$currency) }
+      query($lang:String!,$_0_key_0:[ID!]!,$currency:Currency!,$_1_0_key_0:ID!,$_1_1_key_0:ID!){
+        _0_result: storefronts(ids:$_0_key_0) { name(lang:$lang) }
+        _1_0_result: product(upc:$_1_0_key_0) { price(currency:$currency) }
+        _1_1_result: product(upc:$_1_1_key_0) { price(currency:$currency) }
       }
     |
 
@@ -78,10 +76,10 @@ describe "GraphQL::Stitching::Executor, ResolverSource" do
     query_document, variable_names = @source.build_document(@origin_sets_by_operation, "MyOperation")
 
     expected = %|
-      query MyOperation_2_3($lang:String!,$_0_key:[ID!]!,$currency:Currency!,$_1_0_key:ID!,$_1_1_key:ID!){
-        _0_result: storefronts(ids:$_0_key) { name(lang:$lang) }
-        _1_0_result: product(upc:$_1_0_key) { price(currency:$currency) }
-        _1_1_result: product(upc:$_1_1_key) { price(currency:$currency) }
+      query MyOperation_2_3($lang:String!,$_0_key_0:[ID!]!,$currency:Currency!,$_1_0_key_0:ID!,$_1_1_key_0:ID!){
+        _0_result: storefronts(ids:$_0_key_0) { name(lang:$lang) }
+        _1_0_result: product(upc:$_1_0_key_0) { price(currency:$currency) }
+        _1_1_result: product(upc:$_1_1_key_0) { price(currency:$currency) }
       }
     |
 
@@ -97,10 +95,10 @@ describe "GraphQL::Stitching::Executor, ResolverSource" do
     )
 
     expected = %|
-      query MyOperation_2_3($lang:String!,$_0_key:[ID!]!,$currency:Currency!,$_1_0_key:ID!,$_1_1_key:ID!) @inContext(lang: "EN") {
-        _0_result: storefronts(ids:$_0_key) { name(lang:$lang) }
-        _1_0_result: product(upc:$_1_0_key) { price(currency:$currency) }
-        _1_1_result: product(upc:$_1_1_key) { price(currency:$currency) }
+      query MyOperation_2_3($lang:String!,$_0_key_0:[ID!]!,$currency:Currency!,$_1_0_key_0:ID!,$_1_1_key_0:ID!) @inContext(lang: "EN") {
+        _0_result: storefronts(ids:$_0_key_0) { name(lang:$lang) }
+        _1_0_result: product(upc:$_1_0_key_0) { price(currency:$currency) }
+        _1_1_result: product(upc:$_1_1_key_0) { price(currency:$currency) }
       }
     |
 

--- a/test/graphql/stitching/integration/arguments_test.rb
+++ b/test/graphql/stitching/integration/arguments_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../schemas/arguments"
+
+describe 'GraphQL::Stitching, arguments' do
+  def setup
+    @supergraph = compose_definitions({
+      "args1" => Schemas::Arguments::Arguments1,
+      "args2" => Schemas::Arguments::Arguments2,
+    })
+  end
+
+  def test_stitches_with_enum_argument
+    query = %|{ allMovies { id status } }|
+    result = plan_and_execute(@supergraph, query)
+    expected = {
+      "allMovies" => [
+        { "id" => "1", "status" => "STREAMING" },
+        { "id" => "2", "status" => nil },
+        { "id" => "3", "status" => "STREAMING" },
+      ],
+    }
+
+    assert_equal expected, result["data"]
+  end
+
+  def test_stitches_with_input_object_key
+    query = %|{ allMovies { id director { name } } }|
+    result = plan_and_execute(@supergraph, query)
+    expected = {
+      "allMovies" => [
+        { "id" => "1", "director" => { "name" => "Steven Spielberg" } },
+        { "id" => "2", "director" => { "name" => "Steven Spielberg" } },
+        { "id" => "3", "director" => { "name" => "Christopher Nolan" } },
+      ],
+    }
+
+    assert_equal expected, result["data"]
+  end
+
+  def test_stitches_with_scalar_key
+    query = %|{ allMovies { id studio { name } } }|
+    result = plan_and_execute(@supergraph, query)
+    expected = {
+      "allMovies" => [
+        { "id" => "1", "studio" => { "name" => "Universal" } },
+        { "id" => "2", "studio" => { "name" => "Lucasfilm" } },
+        { "id" => "3", "studio" => { "name" => "Syncopy" } },
+      ],
+    }
+
+    assert_equal expected, result["data"]
+  end
+
+  def test_stitches_with_literal_arguments
+    query = %|{ allMovies { id genres { name } } }|
+    result = plan_and_execute(@supergraph, query)
+    expected = {
+      "allMovies" => [
+        { "id" => "1", "genres" => [{ "name" => "action/adventure" }, { "name" => "action/sci-fi" }] },
+        { "id" => "2", "genres" => [{ "name" => "action" }, { "name" => "action/adventure" }] },
+        { "id" => "3", "genres" => [{ "name" => "action" }, { "name" => "action/thriller" }] },
+      ],
+    }
+
+    assert_equal expected, result["data"]
+  end
+end

--- a/test/graphql/stitching/plan_test.rb
+++ b/test/graphql/stitching/plan_test.rb
@@ -6,11 +6,11 @@ describe "GraphQL::Stitching::Plan" do
   def setup
     @resolver = GraphQL::Stitching::Resolver.new(
       location: "products",
-      field: "storefronts",
-      arg: "ids",
-      key: "id",
+      type_name: "Storefront",
       list: true,
-      type_name: "Storefront"
+      field: "storefronts",
+      key: "id",
+      arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("ids: $.id", "ids: [ID]"),
     )
 
     @op = GraphQL::Stitching::Plan::Op.new(

--- a/test/graphql/stitching/resolver/arguments_test.rb
+++ b/test/graphql/stitching/resolver/arguments_test.rb
@@ -1,0 +1,378 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Stitching::Resolver::ArgumentsTest < Minitest::Test
+  Argument = GraphQL::Stitching::Resolver::Argument
+  ObjectValue = GraphQL::Stitching::Resolver::ObjectValue
+  LiteralValue = GraphQL::Stitching::Resolver::LiteralValue
+  EnumValue = GraphQL::Stitching::Resolver::EnumValue
+  KeyValue = GraphQL::Stitching::Resolver::KeyValue
+
+  class TestSchema < GraphQL::Schema
+    class TestEnum < GraphQL::Schema::Enum
+      value "YES"
+    end
+
+    class ObjectKey < GraphQL::Schema::InputObject
+      graphql_name "ObjectKey"
+
+      argument :slug, String, required: true
+      argument :namespace, String, required: false
+      argument :nested, self, required: false
+      argument :nested_list, [self], required: false
+    end
+
+    class ScalarKey < GraphQL::Schema::Scalar
+      graphql_name "ScalarKey"
+    end
+
+    class Query < GraphQL::Schema::Object
+      field :object_key, Boolean, null: false do |f|
+        f.argument(:key, ObjectKey, required: true)
+        f.argument(:other, String, required: false)
+      end
+
+      field :object_list_key, [Boolean], null: false do |f|
+        f.argument(:keys, [ObjectKey])
+        f.argument(:other, String, required: false)
+      end
+
+      field :scalar_key, Boolean, null: false do |f|
+        f.argument(:key, ScalarKey)
+      end
+
+      field :builtin_scalar_key, Boolean, null: false do |f|
+        f.argument(:key, String)
+      end
+
+      field :enum_key, Boolean, null: false do |f|
+        f.argument(:key, TestEnum)
+      end
+
+      field :basic_key, Boolean, null: false do |f|
+        f.argument(:key, ID, required: true)
+        f.argument(:scope, String, required: false)
+        f.argument(:mode, TestEnum, required: false)
+      end
+    end
+
+    query Query
+  end
+
+  def test_builds_flat_object_key_into_matching_input_object
+    template = "key: {slug: $.slug, namespace: 'sfoo'}, other: $.slug"
+    expected = [Argument.new(
+      name: "key",
+      type_name: "ObjectKey",
+      list: false,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          type_name: "String",
+          value: KeyValue.new(["slug"]),
+        ),
+        Argument.new(
+          name: "namespace",
+          type_name: "String",
+          value: LiteralValue.new("sfoo"),
+        ),
+      ]),
+    ),
+    Argument.new(
+      name: "other",
+      type_name: "String",
+      value: KeyValue.new(["slug"]),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey"))
+  end
+
+  def test_builds_nested_object_key_into_matching_input_objects
+    template = "key: {slug: $.slug, nested:{slug: $.slug, namespace: 'sfoo'}}"
+    expected = [Argument.new(
+      name: "key",
+      type_name: "ObjectKey",
+      list: false,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          type_name: "String",
+          value: KeyValue.new(["slug"]),
+        ),
+        Argument.new(
+          name: "nested",
+          type_name: "ObjectKey",
+          value: ObjectValue.new([
+            Argument.new(
+              name: "slug",
+              type_name: "String",
+              value: KeyValue.new(["slug"]),
+            ),
+            Argument.new(
+              name: "namespace",
+              type_name: "String",
+              value: LiteralValue.new("sfoo"),
+            ),
+          ]),
+        ),
+      ]),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey"))
+  end
+
+  def test_builds_nested_key_paths
+    template = "key: {slug: $.ref.slug}"
+    expected = [Argument.new(
+      name: "key",
+      type_name: "ObjectKey",
+      list: false,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          type_name: "String",
+          value: KeyValue.new(["ref", "slug"]),
+        ),
+      ]),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey"))
+  end
+
+  def test_builds_object_list_keys_into_matching_inputs
+    template = "keys: {slug: $.slug, nestedList: {slug: $.ref.slug}}"
+    expected = [Argument.new(
+      name: "keys",
+      type_name: "ObjectKey",
+      list: true,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          type_name: "String",
+          value: KeyValue.new(["slug"]),
+        ),
+        Argument.new(
+          name: "nestedList",
+          type_name: "ObjectKey",
+          list: true,
+          value: ObjectValue.new([
+            Argument.new(
+              name: "slug",
+              type_name: "String",
+              value: KeyValue.new(["ref", "slug"]),
+            ),
+          ]),
+        ),
+      ]),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectListKey"))
+  end
+
+  def test_builds_objects_into_custom_scalar_with_no_typing
+    template = "key: {slug: $.slug, nested: {slug: $.slug}}"
+    expected = [Argument.new(
+      name: "key",
+      type_name: "ScalarKey",
+      list: false,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          type_name: nil,
+          value: KeyValue.new(["slug"]),
+        ),
+        Argument.new(
+          name: "nested",
+          type_name: nil,
+          value: ObjectValue.new([
+            Argument.new(
+              name: "slug",
+              type_name: nil,
+              value: KeyValue.new(["slug"]),
+            ),
+          ]),
+        ),
+      ]),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments(template, get_field("scalarKey"))
+  end
+
+  def test_errors_for_building_objects_into_builtin_scalars
+    assert_error "can only be built into custom scalar types" do
+      template = "key: {slug: $.slug, namespace: $.namespace}"
+      GraphQL::Stitching::Resolver.parse_arguments(template, get_field("builtinScalarKey"))
+    end
+  end
+
+  def test_errors_for_building_objects_into_non_object_non_scalars
+    assert_error "can only be built into input object and scalar positions" do
+      template = "key: {slug: $.slug, namespace: $.namespace}"
+      GraphQL::Stitching::Resolver.parse_arguments(template, get_field("enumKey"))
+    end
+  end
+
+  def test_errors_building_invalid_root_keys
+    assert_error "`invalid` is not a valid argument" do
+      template = "key: {slug: $.slug, namespace: $.namespace}, invalid: true"
+      GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey"))
+    end
+  end
+
+  def test_errors_building_invalid_object_keys
+    assert_error "`invalid` is not a valid argument" do
+      template = "key: {slug: $.slug, namespace: $.namespace, invalid: true}"
+      GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey"))
+    end
+  end
+
+  def test_errors_omitting_a_required_root_argument
+    assert_error "Required argument `key` has no input" do
+      GraphQL::Stitching::Resolver.parse_arguments(%|other:"test"|, get_field("objectKey"))
+    end
+  end
+
+  def test_errors_omitting_a_required_object_argument
+    assert_error "Required argument `slug` has no input" do
+      GraphQL::Stitching::Resolver.parse_arguments(%|key: {namespace: $.namespace}|, get_field("objectKey"))
+    end
+  end
+
+  def test_errors_building_keys_into_non_list_arguments_for_list_fields
+    assert_error "Cannot use repeatable key `$.slug` in non-list argument `other`" do
+      GraphQL::Stitching::Resolver.parse_arguments(%|keys: {slug: $.slug} other: $.slug|, get_field("objectListKey"))
+    end
+  end
+
+  def test_arguments_build_expected_value_structure
+    template = "key: {slug: $.name, namespace: 'sol', nested:{slug: $.outer.name, namespace: $.outer.galaxy}}"
+    arg = GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey")).first
+
+    origin_obj = {
+      "_export_name" => "neptune",
+      "_export_outer" => {
+        "_export_name" => "saturn",
+        "_export_galaxy" => "milkyway",
+      }
+    }
+
+    expected = {
+      "slug" => "neptune",
+      "namespace" => "sol",
+      "nested" => {
+        "slug" => "saturn",
+        "namespace" => "milkyway",
+      }
+    }
+
+    assert_equal expected, arg.build(origin_obj)
+  end
+
+  def test_arguments_build_primitive_keys
+    template = "key: $.key, scope: 'foo', mode: YES"
+    args = GraphQL::Stitching::Resolver.parse_arguments(template, get_field("basicKey"))
+    origin_obj = { "_export_key" => "123" }
+
+    assert_equal ["123", "foo", "YES"], args.map { _1.build(origin_obj) }
+  end
+
+  def test_arguments_allows_wrapping_parenthesis
+    template = "(key: $.key)"
+    args = GraphQL::Stitching::Resolver.parse_arguments(template, get_field("basicKey"))
+    origin_obj = { "_export_key" => "123" }
+
+    assert_equal ["123"], args.map { _1.build(origin_obj) }
+  end
+
+  def test_prints_argument_object_structures
+    template = "key: {slug: $.name, namespace: 'sol', nested: {slug: $.outer.name, namespace: $.outer.galaxy}}"
+    arg = GraphQL::Stitching::Resolver.parse_arguments(template, get_field("objectKey")).first
+
+    assert_equal template, arg.to_definition
+    assert_equal template.gsub("'", %|"|), arg.print
+    assert_equal "key: ObjectKey!", arg.to_type_definition
+  end
+
+  def test_prints_primitive_argument_types
+    template = "key: $.key, scope: 'foo', mode: YES"
+    args = GraphQL::Stitching::Resolver.parse_arguments(template, get_field("basicKey"))
+
+    assert_equal template, args.map(&:to_definition).join(", ")
+    assert_equal template.gsub("'", %|"|), args.map(&:print).join(", ")
+    assert_equal "key: ID!, scope: String!, mode: TestEnum!", args.map(&:to_type_definition).join(", ")
+  end
+
+  def test_parse_arguments_with_type_defs
+    template = "keys: {slug: $.name, namespace: 'beep'}, other: 'boom'"
+    type_defs = "keys: [ObjectKey], other: String"
+    expected = [Argument.new(
+      name: "keys",
+      type_name: "ObjectKey",
+      list: true,
+      value: ObjectValue.new([
+        Argument.new(
+          name: "slug",
+          value: KeyValue.new(["name"]),
+        ),
+        Argument.new(
+          name: "namespace",
+          value: LiteralValue.new("beep"),
+        ),
+      ]),
+    ),
+    Argument.new(
+      name: "other",
+      type_name: "String",
+      value: LiteralValue.new("boom"),
+    )]
+
+    assert_equal expected, GraphQL::Stitching::Resolver.parse_arguments_with_type_defs(template, type_defs)
+  end
+
+  def test_checks_primitive_values_for_presence_of_keys
+    assert_equal false, Argument.new(name: "test", value: LiteralValue.new("boom")).key?
+    assert_equal false, Argument.new(name: "test", value: EnumValue.new("YES")).key?
+    assert Argument.new(name: "test", value: KeyValue.new("id")).key?
+  end
+
+  def test_checks_composite_values_for_presence_of_keys
+    assert_equal false, Argument.new(
+      name: "test",
+      value: ObjectValue.new([
+        Argument.new(
+          name: "first",
+          value: EnumValue.new(["YES"]),
+        ),
+        Argument.new(
+          name: "second",
+          value: LiteralValue.new("boom"),
+        ),
+      ]),
+    ).key?
+
+    assert Argument.new(
+      name: "test",
+      value: ObjectValue.new([
+        Argument.new(
+          name: "first",
+          value: EnumValue.new(["YES"]),
+        ),
+        Argument.new(
+          name: "second",
+          value: LiteralValue.new("boom"),
+        ),
+        Argument.new(
+          name: "third",
+          value: KeyValue.new("id"),
+        ),
+      ]),
+    ).key?
+  end
+
+  private
+
+  def get_field(field_name)
+    TestSchema.query.get_field(field_name)
+  end
+end

--- a/test/graphql/stitching/supergraph_test.rb
+++ b/test/graphql/stitching/supergraph_test.rb
@@ -88,8 +88,7 @@ describe "GraphQL::Stitching::Supergraph" do
         location: "manufacturers",
         key: "id",
         field: "manufacturer",
-        arg: "id",
-        arg_type_name: "ID",
+        arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("id: $.id", "id: ID"),
       ),
     ],
     "Product" => [
@@ -97,8 +96,7 @@ describe "GraphQL::Stitching::Supergraph" do
         location: "products",
         key: "upc",
         field: "products",
-        arg: "upc",
-        arg_type_name: "ID",
+        arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("upc: $.upc", "upc: ID"),
       ),
     ],
     "Storefront" => [
@@ -106,8 +104,7 @@ describe "GraphQL::Stitching::Supergraph" do
         location: "storefronts",
         key: "id",
         field: "storefronts",
-        arg: "id",
-        arg_type_name: "ID",
+        arguments: GraphQL::Stitching::Resolver.parse_arguments_with_type_defs("id: $.id", "id: ID"),
       ),
     ],
   }
@@ -240,16 +237,16 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c })
 
     routes = supergraph.route_type_to_locations("T", "a", ["b", "c"])
-    assert_equal ["b"], routes["b"].map { _1["location"] }
-    assert_equal ["b", "c"], routes["c"].map { _1["location"] }
+    assert_equal ["b"], routes["b"].map { _1.location }
+    assert_equal ["b", "c"], routes["c"].map { _1.location }
 
     routes = supergraph.route_type_to_locations("T", "b", ["a", "c"])
-    assert_equal ["a"], routes["a"].map { _1["location"] }
-    assert_equal ["c"], routes["c"].map { _1["location"] }
+    assert_equal ["a"], routes["a"].map { _1.location }
+    assert_equal ["c"], routes["c"].map { _1.location }
 
     routes = supergraph.route_type_to_locations("T", "c", ["a", "b"])
-    assert_equal ["b", "a"], routes["a"].map { _1["location"] }
-    assert_equal ["b"], routes["b"].map { _1["location"] }
+    assert_equal ["b", "a"], routes["a"].map { _1.location }
+    assert_equal ["b"], routes["b"].map { _1.location }
   end
 
   def test_route_type_to_locations_favors_longer_paths_through_necessary_locations
@@ -289,8 +286,8 @@ describe "GraphQL::Stitching::Supergraph" do
     supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c, "d" => d, "e" => e })
 
     routes = supergraph.route_type_to_locations("T", "a", ["b", "c", "d"])
-    assert_equal ["b", "c", "d"], routes["d"].map { _1["location"] }
-    assert routes.none? { |_key, path| path.any? { _1["location"] == "e" } }
+    assert_equal ["b", "c", "d"], routes["d"].map { _1.location }
+    assert routes.none? { |_key, path| path.any? { _1.location == "e" } }
   end
 
   describe "#to_definition / #from_definition" do
@@ -314,11 +311,11 @@ describe "GraphQL::Stitching::Supergraph" do
       assert @schema_sdl.include?("directive @resolver")
       assert @schema_sdl.include?("directive @source")
       assert @schema_sdl.include?(squish_string(%|
-        interface I @resolver(location: "alpha", key: "id", field: "a", arg: "id", argTypeName: "ID") {
+        interface I @resolver(location: "alpha", key: "id", field: "a", arguments: "id: $.id", argumentTypes: "id: ID!") {
       |))
       assert @schema_sdl.include?(squish_string(%|
-        type T implements I @resolver(location: "bravo", key: "id", field: "b", arg: "id", argTypeName: "ID")
-                            @resolver(typeName: "I", location: "alpha", key: "id", field: "a", arg: "id", argTypeName: "ID") {
+        type T implements I @resolver(location: "bravo", key: "id", field: "b", arguments: "id: $.id", argumentTypes: "id: ID!")
+                            @resolver(location: "alpha", key: "id", field: "a", arguments: "id: $.id", argumentTypes: "id: ID!", typeName: "I") {
       |))
       assert @schema_sdl.include?(%|id: ID! @source(location: "alpha") @source(location: "bravo")|)
       assert @schema_sdl.include?(%|a: String @source(location: "alpha")|)

--- a/test/schemas/arguments.rb
+++ b/test/schemas/arguments.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Schemas
+  module Arguments
+    class StitchingResolver < GraphQL::Schema::Directive
+      graphql_name "stitch"
+      locations FIELD_DEFINITION
+      argument :key, String, required: true
+      argument :arguments, String, required: false
+      repeatable true
+    end
+
+    DIRECTORS = [
+      { id: "1", name: "Steven Spielberg" },
+      { id: "2", name: "Christopher Nolan" },
+    ].freeze
+
+    STUDIOS = [
+      { id: "1", name: "Universal" },
+      { id: "2", name: "Lucasfilm" },
+      { id: "3", name: "Syncopy" },
+    ].freeze
+
+    GENRES = [
+      { id: "1", name: "action" },
+      { id: "2", name: "adventure" },
+      { id: "3", name: "sci-fi" },
+      { id: "4", name: "thriller" },
+    ].freeze
+
+    MOVIES = [
+      {
+        id: "1",
+        title: "Jurassic Park",
+        status: "STREAMING",
+        genres: [GENRES[1], GENRES[2]],
+        director: DIRECTORS[0],
+        studio: STUDIOS[0],
+      },
+      {
+        id: "2",
+        title: "Indiana Jones: Raiders of the Lost Arc",
+        status: "IN_THEATERS",
+        genres: [GENRES[0], GENRES[1]],
+        director: DIRECTORS[0],
+        studio: STUDIOS[1],
+      },
+      {
+        id: "3",
+        title: "Inception",
+        status: "STREAMING",
+        genres: [GENRES[0], GENRES[3]],
+        director: DIRECTORS[1],
+        studio: STUDIOS[2],
+      },
+    ].freeze
+
+    class Arguments1 < GraphQL::Schema
+      class Director < GraphQL::Schema::Object
+        field :id, ID, null: false
+      end
+
+      class Genre < GraphQL::Schema::Object
+        field :id, ID, null: false
+      end
+
+      class Studio < GraphQL::Schema::Object
+        field :id, ID, null: false
+      end
+
+      class Movie < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :title, String, null: false
+        field :director, Director, null: false
+        field :genres, [Genre], null: false
+        field :studio, Studio, null: false
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :movies, [Movie, null: true], null: false do
+          directive StitchingResolver, key: "id"
+          argument :ids, [ID], required: true
+        end
+
+        def movies(ids:)
+          ids.map { |id| MOVIES.find { _1[:id] == id } }
+        end
+
+        field :all_movies, [Movie], null: false
+
+        def all_movies
+          MOVIES
+        end
+      end
+
+      query Query
+    end
+
+    class Arguments2 < GraphQL::Schema
+      class Director < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :name, String, null: false
+      end
+
+      class Studio < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :name, String, null: false
+      end
+
+      class Genre < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :name, String, null: false
+      end
+
+      class MovieStatus < GraphQL::Schema::Enum
+        value "IN_THEATERS"
+        value "STREAMING"
+      end
+
+      class Movie < GraphQL::Schema::Object
+        field :id, ID, null: false
+        field :status, MovieStatus, null: true
+      end
+
+      class ComplexKey <  GraphQL::Schema::InputObject
+        argument :id, String, required: false
+        argument :subkey, ComplexKey, required: false
+      end
+
+      class ScalarKey <  GraphQL::Schema::Scalar
+        graphql_name "_Any"
+      end
+
+      class Query < GraphQL::Schema::Object
+        field :movies2, [Movie, null: true], null: false do
+          directive StitchingResolver, key: "id", arguments: "ids: $.id, status: STREAMING"
+          argument :ids, [ID], required: true
+          argument :status, MovieStatus, required: true
+        end
+
+        def movies2(ids:, status: nil)
+          visible_movies = MOVIES.filter { _1[:status] == status }
+          ids.map { |id| visible_movies.find { _1[:id] == id } }
+        end
+
+        field :director, Director, null: false do
+          directive StitchingResolver, key: "id", arguments: "key: { subkey: { id: $.id } }"
+          argument :key, ComplexKey, required: true
+        end
+
+        def director(key:)
+          DIRECTORS.find { _1[:id] == key.dig(:subkey, :id) }
+        end
+
+        field :studios, [Studio, null: true], null: false do
+          directive StitchingResolver, key: "id", arguments: "keys: { subkey: { id: $.id } }"
+          argument :keys, [ScalarKey], required: true
+        end
+
+        def studios(keys:)
+          keys.map { |key| STUDIOS.find { |s| s[:id] == key.dig("subkey", "id") } }
+        end
+
+        field :genres, [Genre, null: true], null: false do
+          directive StitchingResolver, key: "id", arguments: "keys: $.id, prefix: 'action'"
+          argument :keys, [ID], required: true
+          argument :prefix, String, required: false
+        end
+
+        def genres(keys:, prefix:)
+          keys.map do |key|
+            genre = GENRES.find { _1[:id] == key }
+            if genre && genre[:name] != prefix
+              genre.merge(name: "#{prefix}/#{genre[:name]}")
+            else
+              genre
+            end
+          end
+        end
+      end
+
+      query Query
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ require 'graphql/stitching'
 
 ComposerError = GraphQL::Stitching::Composer::ComposerError
 ValidationError = GraphQL::Stitching::Composer::ValidationError
-STITCH_DEFINITION = "directive @stitch(key: String!, typeName: String, representations: Boolean=false) repeatable on FIELD_DEFINITION\n"
+STITCH_DEFINITION = "directive @stitch(key: String!, arguments: String, typeName: String) repeatable on FIELD_DEFINITION\n"
 
 def squish_string(str)
   str.gsub(/\s+/, " ").strip


### PR DESCRIPTION
Introduces argument shapes.

## Minor breaking changes

The previous key-alias-to-argument pattern is deprecated in favor of argument templates. This new pattern can directly replace the old syntax:

```graphql
type Query {
  # Turn this...
  product(byId: ID!): Product @stitch(key: "byId:id")

  # Into this...
  product(byId: ID!): Product @stitch(key: "id", arguments: "byId: $.id")
}
```

## Argument shapes

Stitching infers which argument to use for queries with a single argument, or when the key name matches its intended argument. For custom mappings, the `arguments` option may specify a template of GraphQL arguments that insert key selections:

```graphql
type Product {
  id: ID!
}
type Query {
  product(byId: ID, bySku: ID): Product @stitch(key: "id", arguments: "byId: $.id")
}
```

Key insertions are prefixed by `$.`, and presently support the named resolver key and `__typename`. This syntax allows key selections to be sent as flexible input shapes with multiple arguments, input objects, and/or other literal values:

```graphql
type Product {
  id: ID!
}

union Entity = Product

input EntityKey {
  id: ID!
  typeName: String!
}

type Query {
  entities(keys: [EntityKey!]!, source: String="database"): [Entity]! @stitch(
    key: "id",
    arguments: "keys: { id: $.id, typeName: $.__typename }, source: 'cache'"
  )
}
```