### PR TITLE
Refactor "candidate" naming

### DIFF
--- a/lib/graphql/stitching/composer/validate_resolvers.rb
+++ b/lib/graphql/stitching/composer/validate_resolvers.rb
@@ -12,21 +12,21 @@ module GraphQL::Stitching
           next if type.graphql_name.start_with?("__")
 
           # multiple subschemas implement the type
-          candidate_types_by_location = composer.candidate_types_by_name_and_location[type_name]
-          next unless candidate_types_by_location.length > 1
+          subgraph_types_by_location = composer.subgraph_types_by_name_and_location[type_name]
+          next unless subgraph_types_by_location.length > 1
 
           resolvers = supergraph.resolvers[type_name]
           if resolvers&.any?
-            validate_as_resolver(supergraph, type, candidate_types_by_location, resolvers)
+            validate_as_resolver(supergraph, type, subgraph_types_by_location, resolvers)
           elsif type.kind.object?
-            validate_as_shared(supergraph, type, candidate_types_by_location)
+            validate_as_shared(supergraph, type, subgraph_types_by_location)
           end
         end
       end
 
       private
 
-      def validate_as_resolver(supergraph, type, candidate_types_by_location, resolvers)
+      def validate_as_resolver(supergraph, type, subgraph_types_by_location, resolvers)
         # abstract resolvers are expanded with their concrete implementations, which each get validated. Ignore the abstract itself.
         return if type.kind.abstract?
 
@@ -62,7 +62,7 @@ module GraphQL::Stitching
 
         # verify that all outbound locations can access all inbound locations
         resolver_locations = resolvers_by_location_and_key.keys
-        candidate_types_by_location.each_key do |location|
+        subgraph_types_by_location.each_key do |location|
           remote_locations = resolver_locations.reject { _1 == location }
           paths = supergraph.route_type_to_locations(type.graphql_name, location, remote_locations)
           if paths.length != remote_locations.length || paths.any? { |_loc, path| path.nil? }
@@ -72,7 +72,7 @@ module GraphQL::Stitching
         end
       end
 
-      def validate_as_shared(supergraph, type, candidate_types_by_location)
+      def validate_as_shared(supergraph, type, subgraph_types_by_location)
         expected_fields = begin
           type.fields.keys.sort
         rescue StandardError => e
@@ -84,8 +84,8 @@ module GraphQL::Stitching
           end
         end
 
-        candidate_types_by_location.each do |location, candidate_type|
-          if candidate_type.fields.keys.sort != expected_fields
+        subgraph_types_by_location.each do |location, subgraph_type|
+          if subgraph_type.fields.keys.sort != expected_fields
             raise Composer::ValidationError, "Shared type `#{type.graphql_name}` must have consistent fields across locations, "\
               "or else define resolver queries so that its unique fields may be accessed remotely."
           end


### PR DESCRIPTION
Removing another confusing legacy term from the codebase. A "candidate" was an individual subgraph member. Let's just call them "subgraph" members. 