### PR TITLE
Refactor error types

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -8,6 +8,8 @@ module GraphQL
     EMPTY_ARRAY = [].freeze
 
     class StitchingError < StandardError; end
+    class CompositionError < StitchingError; end
+    class ValidationError < CompositionError; end
 
     class << self
       def stitch_directive

--- a/lib/graphql/stitching/composer/resolver_config.rb
+++ b/lib/graphql/stitching/composer/resolver_config.rb
@@ -12,10 +12,10 @@ module GraphQL::Stitching
 
           assignments.each_with_object({}) do |kwargs, memo|
             type = kwargs[:parent_type_name] ? schema.get_type(kwargs[:parent_type_name]) : schema.query
-            raise ComposerError, "Invalid stitch directive type `#{kwargs[:parent_type_name]}`" unless type
+            raise CompositionError, "Invalid stitch directive type `#{kwargs[:parent_type_name]}`" unless type
 
             field = type.get_field(kwargs[:field_name])
-            raise ComposerError, "Invalid stitch directive field `#{kwargs[:field_name]}`" unless field
+            raise CompositionError, "Invalid stitch directive field `#{kwargs[:field_name]}`" unless field
 
             field_path = "#{location}.#{field.name}"
             memo[field_path] ||= []
@@ -31,7 +31,7 @@ module GraphQL::Stitching
               next unless directive.graphql_name == "key"
 
               key = directive.arguments.keyword_arguments.fetch(:fields).strip
-              raise ComposerError, "Composite federation keys are not supported." unless /^\w+$/.match?(key)
+              raise CompositionError, "Composite federation keys are not supported." unless /^\w+$/.match?(key)
 
               field_path = "#{location}._entities"
               memo[field_path] ||= []

--- a/lib/graphql/stitching/composer/validate_interfaces.rb
+++ b/lib/graphql/stitching/composer/validate_interfaces.rb
@@ -15,7 +15,7 @@ module GraphQL::Stitching
               # graphql-ruby will dynamically apply interface fields on a type implementation,
               # so check the delegation map to assure that all materialized fields have resolver locations.
               unless supergraph.locations_by_type_and_field[possible_type.graphql_name][field_name]&.any?
-                raise Composer::ValidationError, "Type #{possible_type.graphql_name} does not implement a `#{field_name}` field in any location, "\
+                raise ValidationError, "Type #{possible_type.graphql_name} does not implement a `#{field_name}` field in any location, "\
                   "which is required by interface #{interface_type.graphql_name}."
               end
 
@@ -24,7 +24,7 @@ module GraphQL::Stitching
               possible_type_structure = Util.flatten_type_structure(intersecting_field.type)
 
               if possible_type_structure.length != interface_type_structure.length
-                raise Composer::ValidationError, "Incompatible list structures between field #{possible_type.graphql_name}.#{field_name} of type "\
+                raise ValidationError, "Incompatible list structures between field #{possible_type.graphql_name}.#{field_name} of type "\
                   "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
               end
 
@@ -32,12 +32,12 @@ module GraphQL::Stitching
                 possible_struct = possible_type_structure[index]
 
                 if possible_struct.name != interface_struct.name
-                  raise Composer::ValidationError, "Incompatible named types between field #{possible_type.graphql_name}.#{field_name} of type "\
+                  raise ValidationError, "Incompatible named types between field #{possible_type.graphql_name}.#{field_name} of type "\
                     "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end
 
                 if possible_struct.null? && interface_struct.non_null?
-                  raise Composer::ValidationError, "Incompatible nullability between field #{possible_type.graphql_name}.#{field_name} of type "\
+                  raise ValidationError, "Incompatible nullability between field #{possible_type.graphql_name}.#{field_name} of type "\
                     "#{intersecting_field.type.to_type_signature} and interface #{interface_type.graphql_name}.#{field_name} of type #{interface_field.type.to_type_signature}."
                 end
               end

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -153,7 +153,7 @@ module GraphQL
           end
 
         else
-          raise "Invalid operation type."
+          raise StitchingError, "Invalid operation type."
         end
       end
 
@@ -173,7 +173,7 @@ module GraphQL
             each_field_in_scope(parent_type, fragment.selections, &block)
 
           else
-            raise "Unexpected node of type #{node.class.name} in selection set."
+            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
           end
         end
       end
@@ -255,7 +255,7 @@ module GraphQL
             end
 
           else
-            raise "Unexpected node of type #{node.class.name} in selection set."
+            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
           end
         end
 

--- a/lib/graphql/stitching/resolver/arguments.rb
+++ b/lib/graphql/stitching/resolver/arguments.rb
@@ -179,7 +179,7 @@ module GraphQL::Stitching
         if argument_defs
           argument_defs.each_value do |argument_def|
             if argument_def.type.non_null? && !nodes.find { _1.name == argument_def.graphql_name }
-              raise "Required argument `#{argument_def.graphql_name}` has no input."
+              raise CompositionError, "Required argument `#{argument_def.graphql_name}` has no input."
             end
           end
         end
@@ -187,7 +187,7 @@ module GraphQL::Stitching
         nodes.map do |n|
           argument_def = if argument_defs
             unless d = argument_defs[n.name]
-              raise "Input `#{n.name}` is not a valid argument."
+              raise CompositionError, "Input `#{n.name}` is not a valid argument."
             end
 
             # lock the use of keys in a root argument's subtree
@@ -208,7 +208,7 @@ module GraphQL::Stitching
           ArgumentEnumValue.new(node.value.name)
         elsif node.value.is_a?(String) && node.value.start_with?("$.")
           if static_scope
-            raise "Cannot use repeatable key `#{node.value}` in non-list argument `#{argument_def&.graphql_name}`."
+            raise CompositionError, "Cannot use repeatable key `#{node.value}` in non-list argument `#{argument_def&.graphql_name}`."
           end
           KeyArgumentValue.new(node.value.sub(/^\$\./, "").split("."))
         else
@@ -227,9 +227,9 @@ module GraphQL::Stitching
       def build_object_value(node, object_def, static_scope: false)
         if object_def
           if !object_def.kind.input_object? && !object_def.kind.scalar?
-            raise "Objects can only be built into input object and scalar positions."
+            raise CompositionError, "Objects can only be built into input object and scalar positions."
           elsif object_def.kind.scalar? && GraphQL::Schema::BUILT_IN_TYPES[object_def.graphql_name]
-            raise "Objects can only be built into custom scalar types."
+            raise CompositionError, "Objects can only be built into custom scalar types."
           elsif object_def.kind.scalar?
             object_def = nil
           end

--- a/lib/graphql/stitching/shaper.rb
+++ b/lib/graphql/stitching/shaper.rb
@@ -64,7 +64,7 @@ module GraphQL
             return nil if result.nil?
 
           else
-            raise "Unexpected node of type #{node.class.name} in selection set."
+            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
           end
         end
 

--- a/test/graphql/stitching/composer/merge_arguments_test.rb
+++ b/test/graphql/stitching/composer/merge_arguments_test.rb
@@ -26,7 +26,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "input Test { arg:Int } type Query { test(arg:Test):String }"
     b = "input Test { arg:String } type Query { test(arg:Test):String }"
 
-    assert_error('Cannot compose mixed types at `Test.arg`', ComposerError) do
+    assert_error('Cannot compose mixed types at `Test.arg`', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -35,7 +35,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "type Query { test(arg:Int):String }"
     b = "type Query { test(arg:String):String }"
 
-    assert_error('Cannot compose mixed types at `Query.test.arg`', ComposerError) do
+    assert_error('Cannot compose mixed types at `Query.test.arg`', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -71,7 +71,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "input Test { arg:[[String!]] } type Query { test:Test }"
     b = "input Test { arg:[String!] } type Query { test:Test }"
 
-    assert_error('Cannot compose mixed list structures at `Test.arg`.', ComposerError) do
+    assert_error('Cannot compose mixed list structures at `Test.arg`.', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -80,7 +80,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "type Query { test(arg:[String]):String }"
     b = "type Query { test(arg:[[String]]):String }"
 
-    assert_error('Cannot compose mixed list structures at `Query.test.arg`.', ComposerError) do
+    assert_error('Cannot compose mixed list structures at `Query.test.arg`.', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -141,7 +141,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "input Test { arg1:String! } type Query { test(arg:Test):String }"
     b = "input Test { arg2:String } type Query { test(arg:Test):String }"
 
-    assert_error('Required argument `Test.arg1` must be defined in all locations.', ComposerError) do
+    assert_error('Required argument `Test.arg1` must be defined in all locations.', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -150,7 +150,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     a = "type Query { test(arg1:String):String }"
     b = "type Query { test(arg2:String!):String }"
 
-    assert_error('Required argument `Query.test.arg2` must be defined in all locations.', ComposerError) do
+    assert_error('Required argument `Query.test.arg2` must be defined in all locations.', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end

--- a/test/graphql/stitching/composer/merge_fields_test.rb
+++ b/test/graphql/stitching/composer/merge_fields_test.rb
@@ -64,7 +64,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     a = "type Test { field: String } type Query { test:Test }"
     b = "type Test { field: Int } type Query { test:Test }"
 
-    assert_error "Cannot compose mixed types at `Test.field`", ComposerError do
+    assert_error "Cannot compose mixed types at `Test.field`", CompositionError do
       compose_definitions({ "a" => a, "b" => b })
     end
   end
@@ -98,7 +98,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     a = "type Test { field: [[String!]] } type Query { test:Test }"
     b = "type Test { field: [String!] } type Query { test:Test }"
 
-    assert_error "Cannot compose mixed list structures at `Test.field`", ComposerError do
+    assert_error "Cannot compose mixed list structures at `Test.field`", CompositionError do
       compose_definitions({ "a" => a, "b" => b })
     end
   end

--- a/test/graphql/stitching/composer/merge_root_objects_test.rb
+++ b/test/graphql/stitching/composer/merge_root_objects_test.rb
@@ -40,7 +40,7 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
   def test_errors_for_subscription
     a = "type Query { a:String } type Mutation { a:String } type Subscription { b:String }"
 
-    assert_error('subscription operation is not supported', ComposerError) do
+    assert_error('subscription operation is not supported', CompositionError) do
       compose_definitions({ "a" => a })
     end
   end
@@ -48,7 +48,7 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
   def test_errors_for_query_type_name_conflict
     a = "type Query { a:String } type Boom { a:String }"
 
-    assert_error('Query name "Boom" is used', ComposerError) do
+    assert_error('Query name "Boom" is used', CompositionError) do
       compose_definitions({ "a" => a }, { query_name: "Boom" })
     end
   end
@@ -56,7 +56,7 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
   def test_errors_for_mutation_type_name_conflict
     a = "type Query { a:String } type Mutation { a:String } type Boom { a:String }"
 
-    assert_error('Mutation name "Boom" is used', ComposerError) do
+    assert_error('Mutation name "Boom" is used', CompositionError) do
       compose_definitions({ "a" => a }, { mutation_name: "Boom" })
     end
   end

--- a/test/graphql/stitching/composer/validate_composition_test.rb
+++ b/test/graphql/stitching/composer/validate_composition_test.rb
@@ -7,7 +7,7 @@ describe 'GraphQL::Stitching::Composer, general concerns' do
     a = "type Query { a:Boom } type Boom { a:String }"
     b = "type Query { b:Boom } interface Boom { b:String }"
 
-    assert_error('Cannot merge different kinds for `Boom`. Found: OBJECT, INTERFACE', ComposerError) do
+    assert_error('Cannot merge different kinds for `Boom`. Found: OBJECT, INTERFACE', CompositionError) do
       compose_definitions({ "a" => a, "b" => b })
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,8 +16,8 @@ require 'minitest/pride'
 require 'minitest/autorun'
 require 'graphql/stitching'
 
-ComposerError = GraphQL::Stitching::Composer::ComposerError
-ValidationError = GraphQL::Stitching::Composer::ValidationError
+CompositionError = GraphQL::Stitching::CompositionError
+ValidationError = GraphQL::Stitching::ValidationError
 STITCH_DEFINITION = "directive @stitch(key: String!, arguments: String, typeName: String) repeatable on FIELD_DEFINITION\n"
 
 def squish_string(str)


### PR DESCRIPTION
Move composer errors up to the root library, and raise newly renamed "CompositionError" in response to resolver composition concerns.