### PR TITLE
Restore resolverless key matching

### DIFF
--- a/docs/mechanics.md
+++ b/docs/mechanics.md
@@ -90,7 +90,7 @@ class GraphQlController
       variables: params[:variables],
       operation_name: params[:operation_name]
     )
-  end 
+  end
 end
 ```
 
@@ -345,4 +345,4 @@ type Query {
 }
 ```
 
-In this graph, `Widget` is a merged type without a resolver query in location C. This works because all of its fields are resolvable in other locations; that means location C can provide outbound representations of this type without ever needing to resolve inbound requests for it. Outbound types do still require a shared key field (such as `id` above) that allow them to join with data in other resolver locations (such as `price` above).
+In this graph, `Widget` is a merged type without a resolver query in location C. This works because all of its fields are resolvable in other locations; that means location C can provide outbound representations of this type without ever needing to resolve inbound requests for it. Outbound types do still require a shared key field (such as `id` above) that allow them to join with data in other resolver locations (such as `price` above). Support for this pattern is limited to single-field keys, [composite keys](../README.md#composite-type-keys) require a resolver definition.

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -557,7 +557,7 @@ module GraphQL
                 argument = if subgraph_field.arguments.size == 1
                   subgraph_field.arguments.values.first
                 else
-                  subgraph_field.arguments[key.default_argument_name]
+                  subgraph_field.arguments[key.primitive_name]
                 end
 
                 unless argument
@@ -565,7 +565,7 @@ module GraphQL
                     "An argument mapping is required for unmatched names and composite keys."
                 end
 
-                "#{argument.graphql_name}: $.#{key.default_argument_name}"
+                "#{argument.graphql_name}: $.#{key.primitive_name}"
               end
 
               arguments = Resolver.parse_arguments_with_field(arguments_format, subgraph_field)

--- a/lib/graphql/stitching/composer/validate_resolvers.rb
+++ b/lib/graphql/stitching/composer/validate_resolvers.rb
@@ -55,8 +55,10 @@ module GraphQL::Stitching
         end
 
         # All locations of a merged type must include at least one resolver key
-        supergraph.fields_by_type_and_location[type.graphql_name].each_key do |location|
-          if resolver_keys.none? { _1.locations.include?(location) }
+        supergraph.fields_by_type_and_location[type.graphql_name].each do |location, field_names|
+          has_resolver_key = resolver_keys.any? { _1.locations.include?(location) }
+          has_primitive_match = resolver_keys.any? { field_names.include?(_1.primitive_name) }
+          unless has_resolver_key || has_primitive_match
             raise ValidationError, "A resolver key is required for `#{type.graphql_name}` in #{location} to join with other locations."
           end
         end

--- a/lib/graphql/stitching/resolver/keys.rb
+++ b/lib/graphql/stitching/resolver/keys.rb
@@ -42,7 +42,7 @@ module GraphQL::Stitching
         to_definition == other.to_definition
       end
 
-      def default_argument_name
+      def primitive_name
         length == 1 ? first.name : nil
       end
 

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -147,7 +147,11 @@ module GraphQL
       def possible_keys_for_type_and_location(type_name, location)
         possible_keys_by_type = @possible_keys_by_type_and_location[type_name] ||= {}
         possible_keys_by_type[location] ||= possible_keys_for_type(type_name).select do |key|
-          key.locations.include?(location)
+          next true if key.locations.include?(location)
+
+          # Outbound-only locations without resolver queries may dynamically match primitive keys
+          location_fields = fields_by_type_and_location[type_name][location] || GraphQL::Stitching::EMPTY_ARRAY
+          location_fields.include?(key.primitive_name)
         end
       end
 

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.4.1"
+    VERSION = "1.4.2"
   end
 end

--- a/test/graphql/stitching/composer/validate_resolvers_test.rb
+++ b/test/graphql/stitching/composer/validate_resolvers_test.rb
@@ -160,4 +160,18 @@ describe 'GraphQL::Stitching::Composer, validate resolvers' do
       assert compose_definitions({ "a" => a, "b" => b })
     end
   end
+
+  def test_permits_no_resolver_query_for_abstract_types_that_can_be_fully_resolved_elsewhere
+    a = %|
+      interface I { id:ID! }
+      type T implements I { id:ID! name:String }
+      type Query { a(id:ID!):I @stitch(key: "id") }
+    |
+    b = %|
+      type T { id:ID! }
+      type Query { b:T }
+    |
+
+    assert compose_definitions({ "a" => a, "b" => b })
+  end
 end


### PR DESCRIPTION
As reported by @thomasmarshall, the recent `v1.4.0` release compromised resolverless key matching for [outbound-only types](https://github.com/gmac/graphql-stitching-ruby/blob/main/docs/mechanics.md#outbound-only-merged-types). This should reconcile the original behavior with the new composite internals, and continue supporting single-field key matches. For now composite keys require a resolver implementation.