### PR TITLE
Subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@ GraphQL stitching composes a single schema from multiple underlying GraphQL reso
 ![Stitched graph](./docs/images/stitching.png)
 
 **Supports:**
+- All operation types: query, mutation, and subscription.
 - Merged object and abstract types.
-- Multiple and composite keys per merged type.
 - Shared objects, fields, enums, and inputs across locations.
+- Multiple and composite type keys.
 - Combining local and remote schemas.
 - File uploads via [multipart form spec](https://github.com/jaydenseric/graphql-multipart-request-spec).
 - Tested with all minor versions of `graphql-ruby`.
 
 **NOT Supported:**
 - Computed fields (ie: federation-style `@requires`).
-- Subscriptions, defer/stream.
+- Defer/stream.
 
 This Ruby implementation is a sibling to [GraphQL Tools](https://the-guild.dev/graphql/stitching) (JS) and [Bramble](https://movio.github.io/bramble/) (Go), and its capabilities fall somewhere in between them. GraphQL stitching is similar in concept to [Apollo Federation](https://www.apollographql.com/docs/federation/), though more generic. The opportunity here is for a Ruby application to stitch its local schemas together or onto remote sources without requiring an additional proxy service running in another language. If your goal is to build a purely high-throughput federated reverse proxy, consider not using Ruby.
 
@@ -445,6 +446,7 @@ The [Executor](./docs/executor.md) component builds atop the Ruby fiber-based im
 - [Modeling foreign keys for stitching](./docs/mechanics.md##modeling-foreign-keys-for-stitching)
 - [Deploying a stitched schema](./docs/mechanics.md#deploying-a-stitched-schema)
 - [Schema composition merge patterns](./docs/composer.md#merge-patterns)
+- [Subscriptions tutorial](./docs/subscriptions.md)
 - [Field selection routing](./docs/mechanics.md#field-selection-routing)
 - [Root selection routing](./docs/mechanics.md#root-selection-routing)
 - [Stitched errors](./docs/mechanics.md#stitched-errors)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,4 +15,5 @@ Major components include:
 Additional topics:
 
 - [Stitching mechanics](./mechanics.md) - more about building for stitching and how it operates.
+- [Subscriptions](./subscriptions.md) - explore how to stitch realtime event subscriptions.
 - [Federation entities](./federation_entities.md) - more about Apollo Federation compatibility.

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -1,0 +1,206 @@
+## Stitching subscriptions
+
+Stitching is an interesting prospect for subscriptions because socket-based interactions can be isolated to their own schema/server with very little implementation beyond resolving entity keys. Then, entity data can be stitched onto subscription payloads from other locations.
+
+### Composing a subscriptions schema
+
+For simplicity, subscription resolvers should exist together in a single schema (multiple schemas with subscriptions probably aren't worth the confusion). This subscriptions schema may provide basic entity types that will merge with other locations. For example, here's a bare-bones subscriptions schema:
+
+```ruby
+class SubscriptionSchema < GraphQL::Schema
+  class Post < GraphQL::Schema::Object
+    field :id, ID, null: false
+  end
+
+  class Comment < GraphQL::Schema::Object
+    field :id, ID, null: false
+  end
+
+  class CommentAddedToPost < GraphQL::Schema::Subscription
+    argument :post_id, ID, required: true
+    field :post, Post, null: false
+    field :comment, Comment, null: true
+
+    def subscribe(post_id:)
+      { post: { id: post_id }, comment: nil }
+    end
+
+    def update(post_id:)
+      { post: { id: post_id }, comment: object }
+    end
+  end
+
+  class SubscriptionType < GraphQL::Schema::Object
+    field :comment_added_to_post, subscription: CommentAddedToPost
+  end
+
+  use GraphQL::Subscriptions::ActionCableSubscriptions
+  subscription SubscriptionType
+end
+```
+
+The above subscriptions schema can compose with other locations, such as the following that provides full entity types:
+
+```ruby
+class EntitiesSchema < GraphQL::Schema
+  class StitchingResolver < GraphQL::Schema::Directive
+    graphql_name "stitch"
+    locations FIELD_DEFINITION
+    argument :key, String, required: true
+    argument :arguments, String, required: false
+    repeatable true
+  end
+
+  class Comment < GraphQL::Schema::Object
+    field :id, ID, null: false
+    field :message, String, null: false
+  end
+
+  class Post < GraphQL::Schema::Object
+    field :id, ID, null: false
+    field :title, String, null: false
+    field :comments, [Comment, null: false], null: false
+  end
+
+  class QueryType < GraphQL::Schema::Object
+    field :posts, [Post, null: true] do
+      directive StitchingResolver, key: "id"
+      argument :ids, [ID], required: true
+    end
+
+    def posts(ids:)
+      Post.where(id: ids)
+    end
+
+    field :comments, [Comment, null: true] do
+      directive StitchingResolver, key: "id"
+      argument :ids, [ID], required: true
+    end
+
+    def comments(ids:)
+      Comment.where(id: ids)
+    end
+  end
+
+  query QueryType
+end
+```
+
+These schemas can be composed as normal into a stitching client. The subscriptions schema must be locally-executable while other entity schema(s) may be served from anywhere:
+
+```ruby
+StitchedSchema = GraphQL::Stitching::Client.new(locations: {
+  subscriptions: {
+    schema: SubscriptionSchema, # << locally executable!
+  },
+  entities: {
+    schema: GraphQL::Schema.from_definition(entities_schema_sdl),
+    executable: GraphQL::Stitching::HttpExecutable.new("http://localhost:3001"),
+  },
+})
+```
+
+### Serving stitched subscriptions
+
+Once you've stitched a schema with subscriptions, it gets called as part of three workflows:
+
+1. Controller - handles normal query and mutation requests recieved via HTTP.
+2. Channel - handles subscription-create requests recieved through a socket connection.
+3. Plugin – handles subscription-update events pushed to the socket connection.
+
+#### Controller
+
+A controller will recieve basic query and mutation requests sent over HTTP, including introspection requests. Fulfill these using the stitched schema client.
+
+```ruby
+class GraphqlController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  layout false
+
+  def execute
+    result = StitchedSchema.execute(
+      params[:query],
+      context: {}, 
+      variables: params[:variables],
+      operation_name: params[:operationName],
+    )
+
+    render json: result
+  end
+end
+```
+
+#### Channel
+
+A channel handles subscription requests initiated via websocket connection. This mostly follows the [GraphQL Ruby documentation example](https://graphql-ruby.org/api-doc/2.3.9/GraphQL/Subscriptions/ActionCableSubscriptions), except that `execute` uses the stitched schema client while `unsubscribed` uses the subscriptions subschema directly:
+
+```ruby
+class GraphqlChannel < ApplicationCable::Channel
+  def subscribed
+    @subscription_ids = []
+  end
+
+  def execute(params)
+    result = StitchedSchema.execute(
+      params["query"],
+      context: { channel: self },
+      variables: params["variables"],
+      operation_name: params["operationName"]
+    )
+
+    payload = {
+      result: result.to_h,
+      more: result.subscription?,
+    }
+
+    if result.context[:subscription_id]
+      @subscription_ids << result.context[:subscription_id]
+    end
+
+    transmit(payload)
+  end
+
+  def unsubscribed
+    @subscription_ids.each { |sid|
+      # Go directly through the subscriptions subschema 
+      # when managing/triggering subscriptions:
+      SubscriptionSchema.subscriptions.delete_subscription(sid)
+    }
+  end
+end
+```
+
+What happens behind the scenes here is that stitching filters the `execute` request down to just subscription selections, and passes those through to the subscriptions subschema where they register an event binding. The subscriber response gets stitched while passing back up through the stitching client.
+
+#### Plugin
+
+Lastly, update events trigger with the filtered subscriptions selection, so must get stitched before transmitting. The stitching client adds an update handler into request context for this purpose. A small patch to the subscriptions plugin class can call this handler on update event payloads before transmitting them:
+
+```ruby
+class StitchedActionCableSubscriptions < GraphQL::Subscriptions::ActionCableSubscriptions
+  def execute_update(subscription_id, event, object)
+    super(subscription_id, event, object).tap do |result|
+      result.context[:stitch_subscription_update]&.call(result)
+    end
+  end
+end
+
+class SubscriptionSchema
+  # switch the plugin on the subscriptions schema to use the patched class... 
+  use StitchedActionCableSubscriptions
+end
+```
+
+### Triggering subscriptions
+
+Subscription update events are triggered as normal directly through the subscriptions subschema:
+
+```ruby
+class Comment < ApplicationRecord
+  after_create :trigger_subscriptions
+  
+  def trigger_subscriptions
+    SubscriptionsSchema.subscriptions.trigger(:comment_added_to_post, { post_id: post_id }, self)
+  end
+end
+```

--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -4,6 +4,18 @@ require "graphql"
 
 module GraphQL
   module Stitching
+    # scope name of query operations.
+    QUERY_OP = "query"
+    
+    # scope name of mutation operations.
+    MUTATION_OP = "mutation"
+    
+    # scope name of subscription operations.
+    SUBSCRIPTION_OP = "subscription"
+    
+    # introspection typename field.
+    TYPENAME = "__typename"
+
     # @api private
     EMPTY_OBJECT = {}.freeze
 

--- a/lib/graphql/stitching/composer/resolver_config.rb
+++ b/lib/graphql/stitching/composer/resolver_config.rb
@@ -38,7 +38,7 @@ module GraphQL::Stitching
               memo[field_path] << new(
                 key: key.to_definition,
                 type_name: entity_type.graphql_name,
-                arguments: "representations: { #{key_fields.join(", ")}, __typename: $.__typename }",
+                arguments: "representations: { #{key_fields.join(", ")}, #{TYPENAME}: $.#{TYPENAME} }",
               )
             end
           end

--- a/lib/graphql/stitching/composer/validate_resolvers.rb
+++ b/lib/graphql/stitching/composer/validate_resolvers.rb
@@ -5,10 +5,16 @@ module GraphQL::Stitching
     class ValidateResolvers < BaseValidator
 
       def perform(supergraph, composer)
+        root_types = [
+          supergraph.schema.query,
+          supergraph.schema.mutation,
+          supergraph.schema.subscription,
+        ].tap(&:compact!)
+        
         supergraph.schema.types.each do |type_name, type|
           # objects and interfaces that are not the root operation types
           next unless type.kind.object? || type.kind.interface?
-          next if supergraph.schema.query == type || supergraph.schema.mutation == type
+          next if root_types.include?(type)
           next if type.graphql_name.start_with?("__")
 
           # multiple subschemas implement the type

--- a/lib/graphql/stitching/executor/shaper.rb
+++ b/lib/graphql/stitching/executor/shaper.rb
@@ -105,7 +105,7 @@ module GraphQL::Stitching
         is_root = parent_type == @root_type
 
         case node.name
-        when "__typename"
+        when TYPENAME
           yield(is_root)
           true
         when "__schema", "__type"

--- a/lib/graphql/stitching/resolver/arguments.rb
+++ b/lib/graphql/stitching/resolver/arguments.rb
@@ -130,8 +130,8 @@ module GraphQL::Stitching
 
       def verify_key(arg, key)
         key_field = value.reduce(Resolver::KeyField.new("", inner: key)) do |field, ns|
-          if ns == Resolver::TYPE_NAME
-            Resolver::KeyField.new(Resolver::TYPE_NAME)
+          if ns == TYPENAME
+            Resolver::KeyField.new(TYPENAME)
           elsif field
             field.inner.find { _1.name == ns }
           end

--- a/lib/graphql/stitching/resolver/keys.rb
+++ b/lib/graphql/stitching/resolver/keys.rb
@@ -3,7 +3,6 @@
 module GraphQL::Stitching
   class Resolver
     EXPORT_PREFIX = "_export_"
-    TYPE_NAME = "__typename"
 
     class FieldNode
       # GraphQL Ruby changed the argument assigning Field.alias from
@@ -59,8 +58,8 @@ module GraphQL::Stitching
 
     EMPTY_FIELD_SET = KeyFieldSet.new(GraphQL::Stitching::EMPTY_ARRAY)
     TYPENAME_EXPORT_NODE = FieldNode.build(
-      field_alias: "#{EXPORT_PREFIX}#{TYPE_NAME}",
-      field_name: TYPE_NAME,
+      field_alias: "#{EXPORT_PREFIX}#{TYPENAME}",
+      field_name: TYPENAME,
     )
 
     class Key < KeyFieldSet

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -103,7 +103,7 @@ module GraphQL
           executable.execute(
             query: source,
             variables: variables,
-            context: request.context.frozen? ? request.context.dup : request.context,
+            context: request.context.to_h,
             validate: false,
           )
         elsif executable.respond_to?(:call)

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.4.3"
+    VERSION = "1.5.0"
   end
 end

--- a/test/graphql/stitching/client_test.rb
+++ b/test/graphql/stitching/client_test.rb
@@ -78,7 +78,7 @@ describe "GraphQL::Stitching::Client" do
       operation_name: "MyStore",
     )
 
-    assert_equal @expected_result, result
+    assert_equal @expected_result, result.to_h
   end
 
   def test_execute_valid_query_via_ast
@@ -90,7 +90,7 @@ describe "GraphQL::Stitching::Client" do
       operation_name: "MyStore",
     )
 
-    assert_equal @expected_result, result
+    assert_equal @expected_result, result.to_h
   end
 
   def test_prepares_requests_before_handling
@@ -161,7 +161,7 @@ describe "GraphQL::Stitching::Client" do
       }
     |
 
-    result = @client.execute(query: queries, operation_name: "SecondBest")
+    result = @client.execute(queries, operation_name: "SecondBest")
 
     expected_result = { "data" => { "storefront" => { "id" => "2" } } }
     assert_equal expected_result, result
@@ -179,7 +179,7 @@ describe "GraphQL::Stitching::Client" do
       }
     |
 
-    result = @client.execute(query: queries)
+    result = @client.execute(queries)
 
     expected_errors = [
       { "message" => "An operation name is required when sending multiple operations." },
@@ -194,7 +194,7 @@ describe "GraphQL::Stitching::Client" do
       query { storefront(id: "1") { id } }
     |
 
-    result = @client.execute(query: queries, operation_name: "Sfoo")
+    result = @client.execute(queries, operation_name: "Sfoo")
 
     expected_errors = [
       { "message" => "Invalid root operation for given name and operation type." },
@@ -209,7 +209,7 @@ describe "GraphQL::Stitching::Client" do
       query BestStorefront { sfoo }}
     |
 
-    result = @client.execute(query: queries)
+    result = @client.execute(queries)
     expected_locs = [{ "line" => 2, "column" => 36 }]
 
     assert_equal 1, result["errors"].length
@@ -227,7 +227,7 @@ describe "GraphQL::Stitching::Client" do
       }
     })
 
-    result = client.execute(query: "query { storefront(id: \"1\") { id } }")
+    result = client.execute("query { storefront(id: \"1\") { id } }")
     assert_equal static_remote_data, result
   end
 
@@ -244,7 +244,7 @@ describe "GraphQL::Stitching::Client" do
       }
     |
 
-    result = client.execute(query: query, variables: { "storefrontID" => "1" })
+    result = client.execute(query, variables: { "storefrontID" => "1" })
 
     expected_result = { "data" => { "storefront" => { "id" => "1" } } }
     assert_equal expected_result, result
@@ -263,11 +263,11 @@ describe "GraphQL::Stitching::Client" do
     @client.on_cache_read { |req| cache[req.digest] }
     @client.on_cache_write { |req, payload| cache[req.digest] = payload.gsub("price", "name price") }
 
-    uncached_result = @client.execute(query: test_query)
+    uncached_result = @client.execute(test_query)
     expected_uncached = { "data" => { "product" => { "price" => 699.99 } } }
     assert_equal expected_uncached, uncached_result
 
-    cached_result = @client.execute(query: test_query)
+    cached_result = @client.execute(test_query)
     expected_cached = { "data" => { "product" => { "name" => "iPhone", "price" => 699.99 } } }
     assert_equal expected_cached, cached_result
   end
@@ -292,7 +292,7 @@ describe "GraphQL::Stitching::Client" do
       nil
     end
 
-    client.execute(query: %|{ product(upc: "1") { price } }|, context: context)
+    client.execute(%|{ product(upc: "1") { price } }|, context: context)
     assert_equal context[:key], read_context
     assert_equal context[:key], write_context
   end
@@ -304,7 +304,7 @@ describe "GraphQL::Stitching::Client" do
       }
     })
 
-    result = client.execute(query: "query { invalidSelection }")
+    result = client.execute("query { invalidSelection }")
     expected_errors = [{
       "message" => "Field 'invalidSelection' doesn't exist on type 'Query'",
       "path" => ["query", "invalidSelection"],
@@ -321,7 +321,7 @@ describe "GraphQL::Stitching::Client" do
       }
     })
 
-    result = client.execute(query: 'query { invalidSelection }', validate: false)
+    result = client.execute('query { invalidSelection }', validate: false)
 
     expected_errors = [{
       "message" => "An unexpected error occured.",
@@ -343,7 +343,7 @@ describe "GraphQL::Stitching::Client" do
     end
 
     result = client.execute(
-      query: 'query { invalidSelection }',
+      query: "query { invalidSelection }",
       context: { request_id: "R2d2c3P0" },
       validate: false
     )

--- a/test/graphql/stitching/composer/merge_root_objects_test.rb
+++ b/test/graphql/stitching/composer/merge_root_objects_test.rb
@@ -5,12 +5,13 @@ require "test_helper"
 describe 'GraphQL::Stitching::Composer, merging root objects' do
 
   def test_merges_fields_of_root_scopes
-    a = "type Query { a:String } type Mutation { a:String }"
-    b = "type Query { b:String } type Mutation { b:String }"
+    a = "type Query { a:String } type Mutation { a:String } type Subscription { a:String }"
+    b = "type Query { b:String } type Mutation { b:String } type Subscription { b:String }"
 
     info = compose_definitions({ "a" => a, "b" => b })
     assert_equal ["a","b"], info.schema.types["Query"].fields.keys.sort
     assert_equal ["a","b"], info.schema.types["Mutation"].fields.keys.sort
+    assert_equal ["a","b"], info.schema.types["Subscription"].fields.keys.sort
   end
 
   def test_merges_fields_of_root_scopes_from_custom_names
@@ -35,14 +36,6 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
     assert_equal ["a","b"], info.schema.types["RootMutation"].fields.keys.sort
     assert_nil info.schema.get_type("Query")
     assert_nil info.schema.get_type("Mutation")
-  end
-
-  def test_errors_for_subscription
-    a = "type Query { a:String } type Mutation { a:String } type Subscription { b:String }"
-
-    assert_error('subscription operation is not supported', CompositionError) do
-      compose_definitions({ "a" => a })
-    end
   end
 
   def test_errors_for_query_type_name_conflict

--- a/test/graphql/stitching/executor/shaper_grooming_test.rb
+++ b/test/graphql/stitching/executor/shaper_grooming_test.rb
@@ -161,7 +161,7 @@ describe "GraphQL::Stitching::Executor::Shaper, grooming" do
       INTROSPECTION_QUERY,
     )
 
-    raw = schema.execute(query: INTROSPECTION_QUERY).to_h
+    raw = schema.execute(INTROSPECTION_QUERY).to_h
     assert GraphQL::Stitching::Executor::Shaper.new(request).perform!(raw)
   end
 end

--- a/test/graphql/stitching/integration/subscriptions_test.rb
+++ b/test/graphql/stitching/integration/subscriptions_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../schemas/example"
+require_relative "../../../schemas/subscriptions"
+
+describe 'GraphQL::Stitching, subscriptions' do
+  def setup
+    @supergraph = compose_definitions({
+      "a" => Schemas::Example::Products,
+      "b" => Schemas::Example::Manufacturers,
+      "c" => {
+        schema: Schemas::Subscriptions::SubscriptionSchema,
+        executable: -> (_req, _src, _vars) {
+          { 
+            "data" => { 
+              "updateToProduct" => {
+                "product" => { "_export_upc" => "1", "_export___typename" => "Product" }, 
+                "manufacturer" => nil,
+              },
+            },
+          }
+        },
+      },
+    })
+
+    @query = %|
+      subscription {
+        updateToProduct(upc: "1") {
+          product { name }
+          manufacturer { name }
+        }
+      }
+    |
+
+    @client = GraphQL::Stitching::Client.new(supergraph: @supergraph)
+  end
+
+  def test_subscription_stitches_subscribe_request
+    result = @client.execute(@query)
+    expected = {
+      "data" => {
+        "updateToProduct" => {
+          "product" => { "name" => "iPhone" }, 
+          "manufacturer" => nil,
+        },
+      },
+    }
+
+    assert_equal expected, result.to_h
+  end
+
+  def test_subscription_provides_update_handler
+    result = @client.execute(@query)
+    result.to_h.merge!({
+      "data" => {
+        "updateToProduct" => {
+          "product" => { "_export_upc" => "1", "_export___typename" => "Product" }, 
+          "manufacturer" => { "_export_id" => "1", "_export___typename" => "Manufacturer" },
+        },
+      },
+    })
+
+    expected = {
+      "data" => {
+        "updateToProduct" => {
+          "product" => { "name" => "iPhone" }, 
+          "manufacturer" => { "name" => "Apple" },
+        },
+      },
+    }
+
+    assert_equal expected, result.context[:stitch_subscription_update].call(result).to_h
+  end
+end

--- a/test/schemas/subscriptions.rb
+++ b/test/schemas/subscriptions.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Schemas
+  module Subscriptions
+    class SubscriptionSchema < GraphQL::Schema
+      class Product < GraphQL::Schema::Object
+        field :upc, ID, null: false
+      end
+
+      class Manufacturer < GraphQL::Schema::Object
+        field :id, ID, null: false
+      end
+
+      class UpdateToProduct < GraphQL::Schema::Subscription
+        argument :upc, ID, required: true
+        field :product, Product, null: false
+        field :manufacturer, Manufacturer, null: true
+
+        def subscribe(upc:)
+          { product: { upc: upc }, manufacturer: nil }
+        end
+
+        def update(upc:)
+          { product: { upc: upc }, manufacturer: object }
+        end
+      end
+
+      class SubscriptionType < GraphQL::Schema::Object
+        field :update_to_product, subscription: UpdateToProduct
+      end
+
+      class QueryType < GraphQL::Schema::Object
+        field :ping, String
+      end
+
+      query QueryType
+      subscription SubscriptionType
+    end
+  end
+end


### PR DESCRIPTION
This adds support for stitching subscriptions. See tutorial for full process documentation.

Also switches execution to return results wrapped in a `GraphQL::Query::Result` rather than as a raw hash. This matches GraphQL Ruby better. It shouldn't cause any major disruptions, though if it does, call `to_h` on the result object for the original hash result.