### PR TITLE
GraphQL 2.4 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,11 @@ jobs:
             ruby: 3.1
           - gemfile: gemfiles/graphql_2.0.0.gemfile
             ruby: 3.1
-          - gemfile: gemfiles/graphql_1.13.9.gemfile
+          - gemfile: gemfiles/graphql_2.0.0.gemfile
             ruby: 2.7
-
     steps:
-    - uses: actions/checkout@v2
+    - run: echo BUNDLE_GEMFILE=${{ matrix.gemfile }} > $GITHUB_ENV
+    - uses: actions/checkout@v4
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'graphql', '2.4.4'
-
 gem 'pry'
 gem 'pry-byebug'
 gem 'warning'

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gemspec
 gem 'pry'
 gem 'pry-byebug'
 gem 'warning'
+gem 'minitest-stub-const'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'graphql', '2.4.4'
+
 gem 'pry'
 gem 'pry-byebug'
 gem 'warning'

--- a/gemfiles/graphql_1.13.9.gemfile
+++ b/gemfiles/graphql_1.13.9.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://rubygems.org'
-gemspec
-
-gem 'graphql', '~> 1.13.9'

--- a/gemfiles/graphql_2.0.0.gemfile
+++ b/gemfiles/graphql_2.0.0.gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
 
 gem 'graphql', '~> 2.0.0'
+gem 'warning'
+gem 'minitest-stub-const'
+
+gemspec path: "../"

--- a/gemfiles/graphql_2.1.0.gemfile
+++ b/gemfiles/graphql_2.1.0.gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
 
 gem 'graphql', '~> 2.1.0'
+gem 'warning'
+gem 'minitest-stub-const'
+
+gemspec path: "../"

--- a/gemfiles/graphql_2.2.0.gemfile
+++ b/gemfiles/graphql_2.2.0.gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
 
 gem 'graphql', '~> 2.2.0'
+gem 'warning'
+gem 'minitest-stub-const'
+
+gemspec path: "../"

--- a/gemfiles/graphql_2.3.0.gemfile
+++ b/gemfiles/graphql_2.3.0.gemfile
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-gemspec
 
 gem 'graphql', '~> 2.3.0'
+gem 'warning'
+gem 'minitest-stub-const'
+
+gemspec path: "../"

--- a/graphql-stitching.gemspec
+++ b/graphql-stitching.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'graphql', '>= 1.13.9'
+  spec.add_runtime_dependency 'graphql', '>= 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -25,6 +25,11 @@ module GraphQL
     class StitchingError < StandardError; end
     class CompositionError < StitchingError; end
     class ValidationError < CompositionError; end
+    class DocumentError < StandardError
+      def initialize(element)
+        super("Invalid #{element} encountered in document")
+      end
+    end
 
     class << self
       attr_writer :stitch_directive

--- a/lib/graphql/stitching/client.rb
+++ b/lib/graphql/stitching/client.rb
@@ -7,8 +7,6 @@ module GraphQL
     # Client is an out-of-the-box helper that assembles all 
     # stitching components into a workflow that executes requests.
     class Client
-      class ClientError < StitchingError; end
-
       # @return [Supergraph] composed supergraph that services incoming requests.
       attr_reader :supergraph
 
@@ -18,9 +16,9 @@ module GraphQL
       # @param composer [Composer] optional, a pre-configured composer instance for use with `locations` configuration.
       def initialize(locations: nil, supergraph: nil, composer: nil)
         @supergraph = if locations && supergraph
-          raise ClientError, "Cannot provide both locations and a supergraph."
+          raise ArgumentError, "Cannot provide both locations and a supergraph."
         elsif supergraph && !supergraph.is_a?(Supergraph)
-          raise ClientError, "Provided supergraph must be a GraphQL::Stitching::Supergraph instance."
+          raise ArgumentError, "Provided supergraph must be a GraphQL::Stitching::Supergraph instance."
         elsif supergraph
           supergraph
         else
@@ -58,17 +56,17 @@ module GraphQL
       end
 
       def on_cache_read(&block)
-        raise ClientError, "A cache read block is required." unless block_given?
+        raise ArgumentError, "A cache read block is required." unless block_given?
         @on_cache_read = block
       end
 
       def on_cache_write(&block)
-        raise ClientError, "A cache write block is required." unless block_given?
+        raise ArgumentError, "A cache write block is required." unless block_given?
         @on_cache_write = block
       end
 
       def on_error(&block)
-        raise ClientError, "An error handler block is required." unless block_given?
+        raise ArgumentError, "An error handler block is required." unless block_given?
         @on_error = block
       end
 

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -403,8 +403,8 @@ module GraphQL
             next
           end
 
-          # Getting double args sometimes on auto-generated connection types... why?
-          next if owner.arguments.any? { _1.first == argument_name }
+          # Getting double args sometimes... why?
+          next if owner.arguments(GraphQL::Query::NullContext.instance, false).key?(argument_name)
 
           kwargs = {}
           default_values_by_location = arguments_by_location.each_with_object({}) do |(location, argument), memo|

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -404,7 +404,12 @@ module GraphQL
           end
 
           # Getting double args sometimes... why?
-          next if owner.arguments(GraphQL::Query::NullContext.instance, false).key?(argument_name)
+          begin
+            next if owner.arguments(GraphQL::Query::NullContext.instance, false).key?(argument_name)
+          rescue ArgumentError
+            # pre- graphql v2.4.5
+            next if owner.arguments.key?(argument_name)
+          end
 
           kwargs = {}
           default_values_by_location = arguments_by_location.each_with_object({}) do |(location, argument), memo|

--- a/lib/graphql/stitching/executor.rb
+++ b/lib/graphql/stitching/executor.rb
@@ -27,7 +27,7 @@ module GraphQL
       # Builds a new executor.
       # @param request [Request] the stitching request to execute.
       # @param nonblocking [Boolean] specifies if the dataloader should use async concurrency.
-      def initialize(request, data: {}, errors: [], after: 0, nonblocking: false)
+      def initialize(request, data: {}, errors: [], after: Planner::ROOT_INDEX, nonblocking: false)
         @request = request
         @data = data
         @errors = errors
@@ -38,7 +38,7 @@ module GraphQL
       end
 
       def perform(raw: false)
-        exec!
+        exec!([@after])
         result = {}
 
         if @data && @data.length > 0
@@ -54,7 +54,7 @@ module GraphQL
 
       private
 
-      def exec!(next_steps = [@after])
+      def exec!(next_steps)
         if @exec_cycles > @request.plan.ops.length
           # sanity check... if we've exceeded queue size, then something went wrong.
           raise StitchingError, "Too many execution requests attempted."

--- a/lib/graphql/stitching/executor/shaper.rb
+++ b/lib/graphql/stitching/executor/shaper.rb
@@ -118,7 +118,7 @@ module GraphQL::Stitching
       def typename_in_type?(typename, type)
         return true if type.graphql_name == typename
 
-        type.kind.abstract? && @request.warden.possible_types(type).any? do |t|
+        type.kind.abstract? && @supergraph.schema.possible_types(type).any? do |t|
           t.graphql_name == typename
         end
       end

--- a/lib/graphql/stitching/executor/shaper.rb
+++ b/lib/graphql/stitching/executor/shaper.rb
@@ -64,7 +64,7 @@ module GraphQL::Stitching
             return nil if result.nil?
 
           else
-            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
+            raise DocumentError.new("selection node type")
           end
         end
 

--- a/lib/graphql/stitching/executor/type_resolver_source.rb
+++ b/lib/graphql/stitching/executor/type_resolver_source.rb
@@ -86,7 +86,7 @@ module GraphQL::Stitching
           end
         end
 
-        doc = String.new("query") # << resolver fulfillment always uses query
+        doc = String.new(QUERY_OP) # << resolver fulfillment always uses query
 
         if operation_name
           doc << " #{operation_name}"

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -20,7 +20,7 @@ module GraphQL
       def perform
         build_root_entrypoints
         expand_abstract_resolvers
-        Plan.new(ops: steps.map(&:to_plan_op))
+        Plan.new(ops: steps.map!(&:to_plan_op))
       end
 
       def steps
@@ -76,9 +76,7 @@ module GraphQL
         resolver: nil
       )
         # coalesce repeat parameters into a single entrypoint
-        entrypoint = String.new("#{parent_index}/#{location}/#{parent_type.graphql_name}/#{resolver&.key&.to_definition}/#")
-        path.each { entrypoint << "/#{_1}" }
-
+        entrypoint = [parent_index, location, parent_type.graphql_name, resolver&.key&.to_definition, "#", *path].join("/")
         step = @steps_by_entrypoint[entrypoint]
         next_index = step ? parent_index : @planning_index += 1
 
@@ -156,7 +154,7 @@ module GraphQL
         when SUBSCRIPTION_OP
           # A.3) Permit exactly one subscription field.
           each_field_in_scope(parent_type, @request.operation.selections) do |node|
-            raise StitchingError, "Too many root fields for subscription." unless @steps_by_entrypoint.empty?
+            raise DocumentError.new("root field") unless @steps_by_entrypoint.empty?
 
             locations = @supergraph.locations_by_type_and_field[parent_type.graphql_name][node.name] || SUPERGRAPH_LOCATIONS
             add_step(
@@ -169,7 +167,7 @@ module GraphQL
           end
 
         else
-          raise StitchingError, "Invalid operation type."
+          raise DocumentError.new("operation type")
         end
       end
 
@@ -189,7 +187,7 @@ module GraphQL
             each_field_in_scope(parent_type, fragment.selections, &block)
 
           else
-            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
+            raise DocumentError.new("selection node type")
           end
         end
       end
@@ -271,7 +269,7 @@ module GraphQL
             end
 
           else
-            raise StitchingError, "Unexpected node of type #{node.class.name} in selection set."
+            raise DocumentError.new("selection node type")
           end
         end
 

--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -331,7 +331,7 @@ module GraphQL
         end
 
         if expanded_selections
-          @request.warden.possible_types(parent_type).each do |possible_type|
+          @supergraph.schema.possible_types(parent_type).each do |possible_type|
             next unless @supergraph.locations_by_type[possible_type.graphql_name].include?(current_location)
 
             type_name = GraphQL::Language::Nodes::TypeName.new(name: possible_type.graphql_name)

--- a/lib/graphql/stitching/request.rb
+++ b/lib/graphql/stitching/request.rb
@@ -26,9 +26,6 @@ module GraphQL
       # @return [Hash] contextual object passed through resolver flows.
       attr_reader :context
 
-      # @return [GraphQL::Schema::Warden] a visibility warden for this request.
-      attr_reader :warden
-
       # Creates a new supergraph request.
       # @param supergraph [Supergraph] supergraph instance that resolves the request.
       # @param document [String, GraphQL::Language::Nodes::Document] the request string or parsed AST.
@@ -58,7 +55,6 @@ module GraphQL
         @variables = variables || {}
 
         @query = GraphQL::Query.new(@supergraph.schema, document: @document, context: context)
-        @warden = @query.warden
         @context = @query.context
         @context[:request] = self
       end

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.5.1"
+    VERSION = "1.5.2"
   end
 end

--- a/test/graphql/stitching/planner/plan_root_operations_test.rb
+++ b/test/graphql/stitching/planner/plan_root_operations_test.rb
@@ -135,7 +135,7 @@ describe "GraphQL::Stitching::Planner, root operations" do
       }
     |
 
-    assert_error "Too many root fields" do
+    assert_error "Invalid root field encountered in document" do
       GraphQL::Stitching::Request.new(@supergraph, document).plan
     end
   end

--- a/test/graphql/stitching/request/request_test.rb
+++ b/test/graphql/stitching/request/request_test.rb
@@ -135,12 +135,14 @@ describe "GraphQL::Stitching::Request" do
       }
     |
 
-    request = GraphQL::Stitching::Request.new(@supergraph, string)
     expected = "9f3c5afb51b7155611921d0e8537c8556b8d757ac90b63d85ea52964d18076d0"
     expected_normalized = "71369fe5ee8f33e15b049991a294e6eeeb6e743310c339877f770fa8beb29f21"
-
-    assert_equal expected, request.digest
-    assert_equal expected_normalized, request.normalized_digest
+    
+    GraphQL::Stitching.stub_const(:VERSION, "1.5.1") do
+      request = GraphQL::Stitching::Request.new(@supergraph, string)
+      assert_equal expected, request.digest
+      assert_equal expected_normalized, request.normalized_digest
+    end
   end
 
   def test_prepare_variables_collects_variable_defaults

--- a/test/graphql/stitching_test.rb
+++ b/test/graphql/stitching_test.rb
@@ -7,14 +7,16 @@ describe "GraphQL::Stitching" do
     expected_sha = "f5a163f364ac65dfd8ef60edb3ba39d6c2b44bccc289af3ced96b06e3f25df59"
     expected_md5 = "fec9ff7a551c37ef692994407710fa54"
 
-    fn = GraphQL::Stitching.digest
-    assert_equal expected_sha, new_type_resolver.version
+    GraphQL::Stitching.stub_const(:VERSION, "1.5.1") do
+      fn = GraphQL::Stitching.digest
+      assert_equal expected_sha, new_type_resolver.version
 
-    GraphQL::Stitching.digest { |str| Digest::MD5.hexdigest(str) }
-    assert_equal expected_md5, new_type_resolver.version
+      GraphQL::Stitching.digest { |str| Digest::MD5.hexdigest(str) }
+      assert_equal expected_md5, new_type_resolver.version
 
-    GraphQL::Stitching.digest(&fn)
-    assert_equal expected_sha, new_type_resolver.version
+      GraphQL::Stitching.digest(&fn)
+      assert_equal expected_sha, new_type_resolver.version
+    end
   end
 
   private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ Bundler.require(:default, :test)
 
 require 'minitest/pride'
 require 'minitest/autorun'
+require 'minitest/stub_const'
 require 'graphql/stitching'
 
 CompositionError = GraphQL::Stitching::CompositionError


### PR DESCRIPTION
Library cleanups and compatibility with GraphQL 2.4:

- Separates invalid document errors from stitching errors.
- Fixes InputObject composer warning in GraphQL v2.4.5.
- Drops support for GraphQL 1.13 (CI tests weren't setup correctly, and the library has apparently never worked with that version... so technically not a breaking change)
- Eliminates direct use of warden.