### PR TITLE
GraphQL Ruby 2.5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         include:
           - gemfile: Gemfile
             ruby: 3.3
+          - gemfile: gemfiles/graphql_2.4.0.gemfile
+            ruby: 3.2
           - gemfile: gemfiles/graphql_2.3.0.gemfile
             ruby: 3.2
           - gemfile: gemfiles/graphql_2.2.0.gemfile

--- a/gemfiles/graphql_2.4.0.gemfile
+++ b/gemfiles/graphql_2.4.0.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'graphql', '~> 2.4.0'
+gem 'warning'
+gem 'minitest-stub-const'
+
+gemspec path: "../"

--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -13,11 +13,11 @@ module GraphQL
     class Composer
       # @api private
       NO_DEFAULT_VALUE = begin
-        class T < GraphQL::Schema::Object
+        t = Class.new(GraphQL::Schema::Object) do
           field(:f, String) { _1.argument(:a, String) }
         end
 
-        T.get_field("f").get_argument("a").default_value
+        t.get_field("f").get_argument("a").default_value
       end
 
       # @api private

--- a/lib/graphql/stitching/supergraph.rb
+++ b/lib/graphql/stitching/supergraph.rb
@@ -20,8 +20,6 @@ module GraphQL
 
       def initialize(schema:, fields: {}, resolvers: {}, executables: {})
         @schema = schema
-        @schema.use(GraphQL::Schema::AlwaysVisible)
-
         @resolvers = resolvers
         @resolvers_by_version = nil
         @fields_by_type_and_location = nil

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end


### PR DESCRIPTION
Looks like GraphQL Ruby v2.5 doesn't like to use `GraphQL::Schema::AlwaysVisible`.