### PR TITLE
Skip/include fixes

### DIFF
--- a/lib/graphql/stitching/executor/shaper.rb
+++ b/lib/graphql/stitching/executor/shaper.rb
@@ -32,7 +32,7 @@ module GraphQL::Stitching
             field_name = node.alias || node.name
 
             if @request.query.get_field(parent_type, node.name).introspection?
-              if node.name == TYPENAME && parent_type == @root_type
+              if node.name == TYPENAME && parent_type == @root_type && node != TypeResolver::TYPENAME_EXPORT_NODE
                 raw_object[field_name] = @root_type.graphql_name
               end
               next

--- a/lib/graphql/stitching/version.rb
+++ b/lib/graphql/stitching/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Stitching
-    VERSION = "1.7.1"
+    VERSION = "1.7.2"
   end
 end

--- a/test/graphql/stitching/integration/skip_include_test.rb
+++ b/test/graphql/stitching/integration/skip_include_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../schemas/example"
+
+describe 'GraphQL::Stitching, skip/include' do
+  def setup
+    @supergraph = compose_definitions({
+      "products" => Schemas::Example::Products,
+      "storefronts" => Schemas::Example::Storefronts,
+      "manufacturers" => Schemas::Example::Manufacturers,
+    })
+  end
+
+  def test_skips_partial_object_fields
+    query = %|
+      query($id: ID!) {
+        storefront(id: $id) {
+          products {
+            upc
+            manufacturer @skip(if: true) {
+              name
+            }
+          }
+        }
+      }
+    |
+
+    result = plan_and_execute(@supergraph, query, { "id" => "1" })
+    expected = {
+      "storefront" => {
+        "products" => [
+          { "upc" => "1" },
+          { "upc" => "2" },
+        ],
+      },
+    }
+
+    assert_equal expected, result.dig("data")
+  end
+
+  def test_skips_all_object_fields
+    query = %|
+      query($id: ID!) {
+        storefront(id: $id) {
+          products {
+            manufacturer @skip(if: true) {
+              name
+            }
+          }
+        }
+      }
+    |
+
+    result = plan_and_execute(@supergraph, query, { "id" => "1" })
+    expected = {
+      "storefront" => {
+        "products" => [
+          {},
+          {},
+        ],
+      },
+    }
+
+    assert_equal expected, result.dig("data")
+  end
+
+  def test_skips_partial_root_fields
+    query = %|{
+      product(upc: "1") {
+        upc
+      }
+      storefront(id: "1") @skip(if: true) {
+        id
+      }
+    }|
+
+    result = plan_and_execute(@supergraph, query)
+    expected = {
+      "product" => { "upc" => "1" }
+    }
+
+    assert_equal expected, result.dig("data")
+  end
+
+  def test_skips_all_root_fields
+    query = %|
+      query($id: ID!) {
+        storefront(id: $id) @skip(if: true) {
+          id
+        }
+      }
+    |
+
+    result = plan_and_execute(@supergraph, query, { "id" => "1" })
+    expected = {}
+
+    assert_equal expected, result.dig("data")
+  end
+end


### PR DESCRIPTION
Fixes for skip/include handling, and rolls back some unreleased empty set cases explored in https://github.com/gmac/graphql-stitching-ruby/pull/177.