### PR TITLE
Preserve selection order in stitched result

### DIFF
--- a/lib/graphql/stitching/planner.rb
+++ b/lib/graphql/stitching/planner.rb
@@ -213,7 +213,7 @@ module GraphQL
         input_selections.each do |node|
           case node
           when GraphQL::Language::Nodes::Field
-            if node.alias&.start_with?(TypeResolver::EXPORT_PREFIX) && node != TypeResolver::TYPENAME_EXPORT_NODE
+            if node.alias&.start_with?(TypeResolver::EXPORT_PREFIX) && node.object_id != TypeResolver::TYPENAME_EXPORT_NODE.object_id
               raise StitchingError, %(Alias "#{node.alias}" is not allowed because "#{TypeResolver::EXPORT_PREFIX}" is a reserved prefix.)
             elsif node.name == TYPENAME
               locale_selections << node

--- a/test/graphql/stitching/integration/introspection_test.rb
+++ b/test/graphql/stitching/integration/introspection_test.rb
@@ -51,7 +51,7 @@ describe 'GraphQL::Stitching, introspection' do
       },
     }
 
-    assert_equal expected, result
+    assert_equal expected, result.to_h
   end
 
   def test_performs_type_introspection_with_other_stitching
@@ -83,6 +83,6 @@ describe 'GraphQL::Stitching, introspection' do
       },
     }
 
-    assert_equal expected, result
+    assert_equal expected, result.to_h
   end
 end

--- a/test/graphql/stitching/planner/plan_introspection_test.rb
+++ b/test/graphql/stitching/planner/plan_introspection_test.rb
@@ -62,4 +62,13 @@ describe "GraphQL::Stitching::Planner, introspection" do
       ).plan
     end
   end
+
+  def test_errors_for_reserved_typehint_alias
+    assert_error %|Alias "_export___typename" is not allowed because "_export_" is a reserved prefix| do
+      GraphQL::Stitching::Request.new(
+        @supergraph,
+        %|{ a { _export___typename: __typename } }|,
+      ).plan
+    end
+  end
 end


### PR DESCRIPTION
Adjusts the result shaper to preserve the requested selection order in merged results.