### PR TITLE
Fix camelcase directive kwargs

### DIFF
--- a/lib/graphql/stitching/composer.rb
+++ b/lib/graphql/stitching/composer.rb
@@ -468,8 +468,6 @@ module GraphQL
           kwarg_values_by_name_location = directives_by_location.each_with_object({}) do |(location, directive), memo|
             directive.arguments.keyword_arguments.each do |key, value|
               key = key.to_s
-              next unless directive_class.arguments[key]
-
               memo[key] ||= {}
               memo[key][location] = value
             end


### PR DESCRIPTION
Resolves https://github.com/gmac/graphql-stitching-ruby/issues/183.
Reported by @lish82, thanks!

Issue was that kwarg values are snakecase while the corresponding arguments map has the natural camelcase keys. One solution would be to camelize the argument check. However, kwargs without an argument definition are really more of an error scenario, and do already error in `Schema.from_definition`. 

So, I think we just omit the check and operate on the reasonable assumption that the schema is valid.