### PR TITLE
Client formatting hooks

### DIFF
--- a/lib/graphql/stitching.rb
+++ b/lib/graphql/stitching.rb
@@ -71,6 +71,7 @@ module GraphQL
   end
 end
 
+require_relative "stitching/formatter"
 require_relative "stitching/directives"
 require_relative "stitching/supergraph"
 require_relative "stitching/client"

--- a/lib/graphql/stitching/formatter.rb
+++ b/lib/graphql/stitching/formatter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative "type_resolver/arguments"
+require_relative "type_resolver/keys"
+
+module GraphQL
+  module Stitching
+    module Formatter
+      class Default
+        extend Formatter
+      end
+
+      class Info
+        attr_reader :type_name, :field_name, :argument_name, :enum_value, :directive_name, :kwarg_name
+
+        def initialize(
+          type_name:,
+          field_name: nil,
+          argument_name: nil,
+          enum_value: nil,
+          directive_name: nil,
+          kwarg_name: nil
+        )
+          @type_name = type_name
+          @field_name = field_name
+          @argument_name = argument_name
+          @enum_value = enum_value
+          @directive_name = directive_name
+          @kwarg_name = kwarg_name
+        end
+      end
+
+      def merge_values(values_by_location, _info)
+        values_by_location.each_value.find { !_1.nil? }
+      end
+
+      def merge_descriptions(values_by_location, info)
+        merge_values(values_by_location, info)
+      end
+
+      def merge_deprecations(values_by_location, info)
+        merge_values(values_by_location, info)
+      end
+
+      def merge_default_values(values_by_location, info)
+        merge_values(values_by_location, info)
+      end
+
+      def merge_kwargs(values_by_location, info)
+        if info.directive_name == GraphQL::Stitching.visibility_directive
+          values_by_location.each_value.reduce(:&)
+        else
+          merge_values(values_by_location, info)
+        end
+      end
+
+      def build_graphql_error(_request, _err)
+        { "message" => "An unexpected error occured." }
+      end
+    end
+  end
+end

--- a/test/graphql/stitching/client/class_extension_test.rb
+++ b/test/graphql/stitching/client/class_extension_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../schemas/example"
+
+describe "GraphQL::Stitching::Client" do
+  class MyClient < GraphQL::Stitching::Client
+    def merge_descriptions(values_by_location, _info)
+      values_by_location.values.join("/")
+    end
+
+    def build_graphql_error(request, err)
+      { "message" => "Contact support about request #{request.context[:request_id]}." }
+    end
+  end
+
+  def test_client_acts_as_composition_formatter
+    alpha = %|
+      """
+      a
+      """
+      type Query { a:Boolean }
+    |
+    bravo = %|
+      """
+      b
+      """
+      type Query { b:Boolean }
+    |
+
+    client = MyClient.new(locations: {
+      "alpha" => { schema: GraphQL::Schema.from_definition(alpha) },
+      "bravo" => { schema: GraphQL::Schema.from_definition(bravo) },
+    })
+    
+    assert_equal "a/b", client.supergraph.schema.query.description
+  end
+
+  def test_client_builds_graphql_errors
+    client = MyClient.new(locations: {
+      products: { schema: Schemas::Example::Products },
+    })
+
+    result = client.execute(
+      query: "query { invalidSelection }",
+      context: { request_id: "R2d2c3P0" },
+      validate: false
+    )
+
+    expected_errors = [{
+      "message" => "Contact support about request R2d2c3P0.",
+    }]
+
+    assert_nil result["data"]
+    assert_equal expected_errors, result["errors"]
+  end
+
+  def test_client_from_definition_builds_specific_class
+    alpha = %|
+      type T { id:ID! a:String }
+      type Query { a(id:ID!):T @stitch(key: "id") }
+    |
+    bravo = %|
+      type T { id:ID! b:String }
+      type Query { b(id:ID!):T @stitch(key: "id") }
+    |
+
+    sdl = compose_definitions({ "alpha" => alpha, "bravo" => bravo }).to_definition
+    client = MyClient.from_definition(sdl, executables: {
+      "alpha" => Proc.new {},
+      "bravo" => Proc.new {},
+    })
+    assert client.is_a?(MyClient)
+  end
+end

--- a/test/graphql/stitching/composer/merge_arguments_test.rb
+++ b/test/graphql/stitching/composer/merge_arguments_test.rb
@@ -90,7 +90,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = %|input Test { """b""" arg:String } type Query { test("""b""" arg:Test):String }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].arguments["arg"].description
@@ -102,7 +102,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     b = %|input Test { arg:String @deprecated(reason:"b") } type Query { test(arg:Test @deprecated(reason:"b")):String }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      deprecation_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].arguments["arg"].deprecation_reason
@@ -121,7 +121,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     directive = supergraph.schema.types["Query"].fields["test"].arguments["arg"].directives.first
@@ -170,7 +170,7 @@ describe 'GraphQL::Stitching::Composer, merging object and field arguments' do
     c = %|type Query { test(arg:Int = 2):String }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b, "c" => c }, {
-      default_value_merger: ->(values_by_location, _info) { values_by_location.values.max }
+      formatter: TestFormatter.new,
     })
     assert_equal 2, supergraph.schema.types["Query"].fields["test"].arguments["arg"].default_value
   end

--- a/test/graphql/stitching/composer/merge_directive_test.rb
+++ b/test/graphql/stitching/composer/merge_directive_test.rb
@@ -19,7 +19,7 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     directive_definition = supergraph.schema.directives["fizzbuzz"]
@@ -43,7 +43,7 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     directives = supergraph.schema.types["Test"].directives
@@ -67,7 +67,7 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert !supergraph.schema.directives.key?("stitch")
@@ -92,7 +92,7 @@ describe 'GraphQL::Stitching::Composer, merging directives' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     directives = supergraph.schema.get_type("Test").directives

--- a/test/graphql/stitching/composer/merge_enum_test.rb
+++ b/test/graphql/stitching/composer/merge_enum_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
     b = %|"""b""" enum Status { """b""" YES } type Query { status:Status }|
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Status"].description
@@ -30,7 +30,7 @@ describe 'GraphQL::Stitching::Composer, merging enums' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Status"].directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_fields_test.rb
+++ b/test/graphql/stitching/composer/merge_fields_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = %{type Test { """b""" field: String } type Query { test:Test }}
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].fields["field"].description
@@ -20,7 +20,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     b = %{type Test { field: String @deprecated(reason:"b") } type Query { test:Test }}
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      deprecation_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].fields["field"].deprecation_reason
@@ -38,7 +38,7 @@ describe 'GraphQL::Stitching::Composer, merging object and interface fields' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Query"].fields["test"].directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_input_object_test.rb
+++ b/test/graphql/stitching/composer/merge_input_object_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging input objects' do
     b = %{"""b""" input Test { field:String } type Query { get(test:Test):String }}
 
     info = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", info.schema.types["Test"].description
@@ -29,7 +29,7 @@ describe 'GraphQL::Stitching::Composer, merging input objects' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_interface_test.rb
+++ b/test/graphql/stitching/composer/merge_interface_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging interfaces' do
     b = %{"""b""" interface Test { field: String } type Query { test:Test }}
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].description
@@ -29,7 +29,7 @@ describe 'GraphQL::Stitching::Composer, merging interfaces' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_object_test.rb
+++ b/test/graphql/stitching/composer/merge_object_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging objects' do
     b = %{"""b""" type Test { field: String } type Query { test:Test }}
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].description
@@ -29,7 +29,7 @@ describe 'GraphQL::Stitching::Composer, merging objects' do
     |
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.types["Test"].directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_root_objects_test.rb
+++ b/test/graphql/stitching/composer/merge_root_objects_test.rb
@@ -64,18 +64,6 @@ describe 'GraphQL::Stitching::Composer, merging root objects' do
     assert_equal ["b", "a"], delegation_map["Mutation"]["f"]
   end
 
-  def test_prioritizes_root_field_location_selector_choice
-    a = "type Query { f:String } type Mutation { f:String }"
-    b = "type Query { f:String } type Mutation { f:String }"
-
-    delegation_map = compose_definitions({ "a" => a, "b" => b }, {
-      root_field_location_selector: ->(_locations, _info) { "a" }
-    }).fields
-
-    assert_equal ["a", "b"], delegation_map["Query"]["f"]
-    assert_equal ["a", "b"], delegation_map["Mutation"]["f"]
-  end
-
   def test_prioritizes_root_entrypoints_locations
     a = "type Query { f:String } type Mutation { f:String }"
     b = "type Query { f:String } type Mutation { f:String }"

--- a/test/graphql/stitching/composer/merge_scalar_test.rb
+++ b/test/graphql/stitching/composer/merge_scalar_test.rb
@@ -9,7 +9,7 @@ describe 'GraphQL::Stitching::Composer, merging scalars' do
     b = %{"""b""" scalar URL type Query { url:URL }}
 
     info = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", info.schema.get_type("URL").description
@@ -29,7 +29,7 @@ describe 'GraphQL::Stitching::Composer, merging scalars' do
     GRAPHQL
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.get_type("Thing").directives.first.arguments.keyword_arguments[:arg]

--- a/test/graphql/stitching/composer/merge_union_test.rb
+++ b/test/graphql/stitching/composer/merge_union_test.rb
@@ -18,7 +18,7 @@ describe 'GraphQL::Stitching::Composer, merging unions' do
     b = %{type B { b:Int } """b""" union Thing = B type Query { thing:Thing }}
 
     info = compose_definitions({ "a" => a, "b" => b }, {
-      description_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", info.schema.get_type("Thing").description
@@ -40,7 +40,7 @@ describe 'GraphQL::Stitching::Composer, merging unions' do
     GRAPHQL
 
     supergraph = compose_definitions({ "a" => a, "b" => b }, {
-      directive_kwarg_merger: ->(str_by_location, _info) { str_by_location.values.join("/") }
+      formatter: TestFormatter.new,
     })
 
     assert_equal "a/b", supergraph.schema.get_type("Thing").directives.first.arguments.keyword_arguments[:arg]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,6 @@ Gem.path.each do |path|
   # ignore warnings from auto-generated GraphQL lib code.
   Warning.ignore(/.*mismatched indentations.*/)
   Warning.ignore(/.*lib\/graphql\/language\/nodes.rb:.*/)
-  Warning.ignore(/Composer option `[^`]+` is deprecated.*/)
 end
 
 require 'bundler/setup'
@@ -78,6 +77,19 @@ class SortedSelectionMatcher < Matcher
     end
 
     node.merge(selections: selections)
+  end
+end
+
+class TestFormatter
+  include GraphQL::Stitching::Formatter
+
+  def merge_values(values_by_location, _info)
+    vals = values_by_location.each_value.reject(&:nil?)
+    vals.empty? ? nil : vals.join("/")
+  end
+
+  def merge_default_values(values_by_location, _info)
+    values_by_location.values.max
   end
 end
 


### PR DESCRIPTION
Reorganize formatting hooks (composition mergers, error formatters, etc) into a concern that can be added to various objects. All output formatting methodology is now centralized on one object, and allows `Client` to be that object.
 
### Breaking changes

* Removes `description_merger` composer option. Override `merge_descriptions` client method.
* Removes `deprecation_merger` composer option. Override `merge_deprecations` client method.
* Removes `default_value_merger` composer option. Override `merge_default_values` client method.
* Removes `directive_kwarg_merger` composer option. Override `merge_kwargs` client method.
* Removes `root_field_location_selector` composer option. Use `root_entrypoints` composer option.
* Return from `on_error` hook no longer populates GraphQL error message. Override `build_graphql_error` client method to build the desired error shape.